### PR TITLE
Fix bash completion to work cross-platform (macOS + Linux)

### DIFF
--- a/bash/prompt.sh
+++ b/bash/prompt.sh
@@ -63,8 +63,32 @@ cd  # this is to trigger evaluation of chpwd when shell comes up
 
 
 # enable system bash completion
-if [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && [[ -f "/usr/local/etc/profile.d/bash_completion.sh" ]]; then
+# Try various locations based on OS and package manager
+_bash_completion_loaded=false
+
+if [[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ]]; then
+  # macOS with Homebrew (Apple Silicon)
+  source "/opt/homebrew/etc/profile.d/bash_completion.sh"
+  _bash_completion_loaded=true
+elif [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]]; then
+  # macOS with Homebrew (Intel)
   source "/usr/local/etc/profile.d/bash_completion.sh"
-else
-  errcho "Could not find bash completion script."
+  _bash_completion_loaded=true
+elif [[ -r "/usr/share/bash-completion/bash_completion" ]]; then
+  # Linux (Debian/Ubuntu with bash-completion package)
+  source "/usr/share/bash-completion/bash_completion"
+  _bash_completion_loaded=true
+elif [[ -r "/etc/bash_completion" ]]; then
+  # Linux (older systems / alternative location)
+  source "/etc/bash_completion"
+  _bash_completion_loaded=true
 fi
+
+# If no system-wide bash completion, try to load git completion directly
+if [[ "$_bash_completion_loaded" == "false" ]]; then
+  if [[ -r "/usr/share/bash-completion/completions/git" ]]; then
+    source "/usr/share/bash-completion/completions/git"
+  fi
+fi
+
+unset _bash_completion_loaded


### PR DESCRIPTION
The previous code only checked for the Homebrew/macOS Intel path and would display an error on other systems. Now tries multiple standard locations:
- macOS Homebrew (Apple Silicon): /opt/homebrew/etc/profile.d/bash_completion.sh
- macOS Homebrew (Intel): /usr/local/etc/profile.d/bash_completion.sh
- Linux (bash-completion pkg): /usr/share/bash-completion/bash_completion
- Linux (older): /etc/bash_completion

Falls back to loading git completion directly if no system-wide completion is available.