### PR TITLE
Phase 3: Hash-based idempotency for system modifications

### DIFF
--- a/karabiner/karabiner.sh
+++ b/karabiner/karabiner.sh
@@ -1,27 +1,32 @@
 #!/usr/bin/env bash
 # Module: karabiner
 # Description: Karabiner-Elements config sync (re-links if app breaks symlink)
-# Dependencies: errcho from bash_profile
+# Dependencies: errcho from bash_profile, run_if_changed from 00-dotfiles.sh
 
 KARABINER_CONFIG_DIR="${HOME}/.config/karabiner"
 KARABINER_JSON="${KARABINER_CONFIG_DIR}/karabiner.json"
 DOTFILES_KARABINER="${DOTFILES_DIR}/karabiner/karabiner.json"
 
-# Karabiner app sometimes overwrites the symlink - restore it if needed
-if [[ ! -L "$KARABINER_JSON" ]]; then
-  errcho "karabiner.json is not a symlink"
+# Only check/repair symlink if karabiner config has changed since last run
+# This prevents unnecessary checks and operations on every shell startup
+run_if_changed "karabiner_config" "$DOTFILES_KARABINER" '
+  # Karabiner app sometimes overwrites the symlink - restore it if needed
+  if [[ ! -L "$KARABINER_JSON" ]]; then
+    errcho "karabiner.json is not a symlink"
 
-  # Check if dotfiles version has uncommitted changes
-  local git_status="$(git -C "${DOTFILES_DIR}" status --short)"
-  if [[ "$git_status" =~ "karabiner.json" ]]; then
-    errcho "karabiner.json has uncommitted changes in dotfiles!"
-    errcho "Please review and commit those changes first."
-    echo "$git_status"
-  else
-    # Safe to sync: copy current config to dotfiles, then re-link
-    echo "Copying local karabiner.json to dotfiles repository..."
-    cp -v "$KARABINER_JSON" "$DOTFILES_KARABINER"
-    echo "Re-linking karabiner config to dotfiles..."
-    ln -i -s "$DOTFILES_KARABINER" "$KARABINER_JSON"
+    # Check if dotfiles version has uncommitted changes
+    _git_status="$(git -C "${DOTFILES_DIR}" status --short)"
+    if [[ "$_git_status" =~ "karabiner.json" ]]; then
+      errcho "karabiner.json has uncommitted changes in dotfiles!"
+      errcho "Please review and commit those changes first."
+      echo "$_git_status"
+    else
+      # Safe to sync: copy current config to dotfiles, then re-link
+      echo "Copying local karabiner.json to dotfiles repository..."
+      cp -v "$KARABINER_JSON" "$DOTFILES_KARABINER" || errcho "Failed to copy config"
+      echo "Re-linking karabiner config to dotfiles..."
+      rm -f "$KARABINER_JSON" || errcho "Failed to remove original"
+      ln -s "$DOTFILES_KARABINER" "$KARABINER_JSON" || errcho "Failed to create symlink"
+    fi
   fi
-fi
+'

--- a/osx/osx.sh
+++ b/osx/osx.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 # Module: osx
 # Description: macOS system preferences (keyboard repeat settings)
-# Dependencies: none
+# Dependencies: bash/source/00-dotfiles.sh (run_if_changed)
 
-# Disable press-and-hold for accent characters (enables key repeat for all keys)
-defaults write -g ApplePressAndHoldEnabled -bool false
+# Only apply system preferences if this file has changed since last run
+# This prevents unnecessary `defaults write` calls on every shell startup
+run_if_changed "osx_prefs" "${DOTFILES_DIR}/osx/osx.sh" '
+  # Disable press-and-hold for accent characters (enables key repeat for all keys)
+  defaults write -g ApplePressAndHoldEnabled -bool false
 
-# Set fast key repeat rates
-# InitialKeyRepeat: delay before repeat starts (11 = 165ms)
-# KeyRepeat: speed of repeat (1 = 15ms)
-defaults write -globalDomain InitialKeyRepeat -int 11
-defaults write -globalDomain KeyRepeat -int 1
+  # Set fast key repeat rates
+  # InitialKeyRepeat: delay before repeat starts (11 = 165ms)
+  # KeyRepeat: speed of repeat (1 = 15ms)
+  defaults write -globalDomain InitialKeyRepeat -int 11
+  defaults write -globalDomain KeyRepeat -int 1
+'


### PR DESCRIPTION
## Summary

This PR implements **Phase 3** of the bash cleanup plan, applying hash-based idempotency to prevent unnecessary system modifications during shell initialization.

**Depends on**: #10 (Phase 1 & 2)

### What Changed

✅ **osx/osx.sh** - Applied `run_if_changed()` pattern
- System preferences (`defaults write`) only run when `osx.sh` file changes
- Prevents unnecessary macOS system calls on every shell startup
- Hash stored in `~/.dot/state/osx_prefs.hash`

✅ **karabiner/karabiner.sh** - Applied `run_if_changed()` pattern
- Symlink repair only runs when `karabiner.json` changes
- Fixed `local` keyword issue (not valid outside functions)
- Removed interactive `-i` flag from `ln` command (non-interactive)
- Added proper error handling with `|| errcho`
- Hash stored in `~/.dot/state/karabiner_config.hash`

### How Hash-Based Idempotency Works

```bash
run_if_changed "name" "/path/to/file" 'commands to run'
```

1. Calculate hash of config file using `shasum`
2. Compare with stored hash in `~/.dot/state/name.hash`
3. Only execute commands if hash has changed
4. Update stored hash after successful execution

### Benefits

- **Fast**: Hash comparison is instant (<1ms vs running system commands)
- **Efficient**: System operations only run when config actually changes
- **Idempotent**: Safe to source bash_profile multiple times
- **Self-documenting**: When you change osx.sh or karabiner.json, settings are automatically re-applied

### Testing

All tests pass:
- ✅ All 11 validation tests pass
- ✅ Shell startup successful
- ✅ Hash files created in `~/.dot/state/`
- ✅ Second source skips operations (verified with `DOTFILES_DEBUG=1`)
- ✅ No unexpected system modifications during shell startup

### Example Behavior

**First run (or after changing osx.sh):**
```bash
$ DOTFILES_DEBUG=1 source ~/.bash_profile
run_if_changed: executing osx_prefs (hash changed)
run_if_changed: executing karabiner_config (hash changed)
```

**Subsequent runs:**
```bash
$ DOTFILES_DEBUG=1 source ~/.bash_profile
run_if_changed: no changes detected for osx_prefs
run_if_changed: no changes detected for karabiner_config
```

### Next Steps

Remaining phases after this PR:
- Phase 4: SSH agent improvements
- Phase 5: Code quality fixes
- Phase 6: Testing & documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)