### PR TITLE
Revert virtualenvwrapper commits that were pushed directly to main

### DIFF
--- a/modules/static/41-python.sh
+++ b/modules/static/41-python.sh
@@ -17,13 +17,13 @@ setup_python() {
             unset -f pyenv
             eval "$(command pyenv init -)"
             [[ -d "$(pyenv root)/plugins/pyenv-virtualenvwrapper" ]] && \
-                eval "$(pyenv sh-virtualenvwrapper_lazy)"
+                eval "$(pyenv virtualenvwrapper_lazy)"
             pyenv "$@"
         }
     elif command_exists pyenv; then
         eval "$(pyenv init -)"
         [[ -d "$(pyenv root)/plugins/pyenv-virtualenvwrapper" ]] && \
-            eval "$(pyenv sh-virtualenvwrapper_lazy)"
+            eval "$(pyenv virtualenvwrapper_lazy)"
     fi
 }
 


### PR DESCRIPTION
## Summary
Reverts 3 commits that were pushed directly to main without PR review:
- `836d280` Load virtualenvwrapper immediately while keeping pyenv lazy
- `50baba0` Disable lazy pyenv loading to fix workon availability  
- `0bdde11` Fix virtualenvwrapper initialization (use sh- prefix)

These were urgent bugfixes but should have gone through proper PR process.

## Next Steps
After this merges, will submit proper PR with these fixes on a feature branch for review.

## Reverted Commits
```
git revert 836d280 50baba0 0bdde11
```