### PR TITLE
Tmux: TPM bootstrap, session persistence, and per-pane Claude Code resume (+ CI workflows)

### DIFF
--- a/.github/workflows/claude-on-mention.yml
+++ b/.github/workflows/claude-on-mention.yml
@@ -1,0 +1,46 @@
+name: Claude on @mention
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@3a38b377b30c75102b420405ed9516b57ca2e248 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Allow Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # When @claude is mentioned in an issue, pull request, or comment,
+          # Claude will read and execute the instructions in that mention.
+          # Examples: code review, answering questions, making code changes

--- a/.github/workflows/claude-on-mention.yml
+++ b/.github/workflows/claude-on-mention.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.type != 'Bot') ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.type != 'Bot') ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.review.user.type != 'Bot') ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && github.event.issue.user.type != 'Bot')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,6 +35,8 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@3a38b377b30c75102b420405ed9516b57ca2e248 # v1
         with:
+          # Uses OAuth token for interactive workflows where Claude may need
+          # extended permissions and session management across multiple operations
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Allow Claude to read CI results on PRs

--- a/.github/workflows/claude-on-mention.yml
+++ b/.github/workflows/claude-on-mention.yml
@@ -11,7 +11,7 @@ on:
     types: [submitted]
 
 jobs:
-  claude:
+  claude-respond:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.type != 'Bot') ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.type != 'Bot') ||
@@ -22,7 +22,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
 
     steps:
@@ -32,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Claude Code
-        id: claude
+        id: claude-respond
         uses: anthropics/claude-code-action@3a38b377b30c75102b420405ed9516b57ca2e248 # v1
         with:
           # Uses OAuth token for interactive workflows where Claude may need

--- a/.github/workflows/claude-on-mention.yml
+++ b/.github/workflows/claude-on-mention.yml
@@ -12,11 +12,12 @@ on:
 
 jobs:
   claude-respond:
+    timeout-minutes: 30
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.type != 'Bot') ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.type != 'Bot') ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.review.user.type != 'Bot') ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && github.event.issue.user.type != 'Bot')
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.type != 'Bot' && github.event.comment.user.type != 'bot') ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.type != 'Bot' && github.event.comment.user.type != 'bot') ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.review.user.type != 'Bot' && github.event.review.user.type != 'bot') ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && github.event.issue.user.type != 'Bot' && github.event.issue.user.type != 'bot')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,10 +38,6 @@ jobs:
           # Uses OAuth token for interactive workflows where Claude may need
           # extended permissions and session management across multiple operations
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # Allow Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
 
           # When @claude is mentioned in an issue, pull request, or comment,
           # Claude will read and execute the instructions in that mention.

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,47 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    # Only run on internal PRs (not from forks)
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@3a38b377b30c75102b420405ed9516b57ca2e248 # v1
+        with:
+          allowed_bots: "Copilot,copilot-swe-agent"
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and adherence to engineering standards (docs/ENGINEERING_STANDARDS.md)
+            - Python best practices (type hints, error handling, docstrings)
+            - Potential bugs or issues
+            - Security concerns
+            - Test coverage
+
+            Be constructive and helpful in your feedback. Focus on substantive issues, not nitpicks.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        continue-on-error: true  # Don't block PR if Claude fails
         uses: anthropics/claude-code-action@3a38b377b30c75102b420405ed9516b57ca2e248 # v1
         with:
           allowed_bots: "Copilot,copilot-swe-agent"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -37,7 +37,7 @@ jobs:
             PR NUMBER: ${{ github.event.pull_request.number }}
 
             Please review this pull request and provide feedback on:
-            - Code quality and adherence to engineering standards (CONTRIBUTING.md)
+            - Code quality and adherence to engineering standards (docs/ENGINEERING_STANDARDS.md)
             - Shell script best practices (ShellCheck compliance, quoting, error handling)
             - Module headers and documentation
             - Platform detection and compatibility

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -26,6 +26,8 @@ jobs:
         uses: anthropics/claude-code-action@3a38b377b30c75102b420405ed9516b57ca2e248 # v1
         with:
           allowed_bots: "Copilot,copilot-swe-agent"
+          # Uses API key for automated reviews - simpler authentication for
+          # single-purpose, non-interactive workflows with limited scope
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: true
@@ -34,11 +36,14 @@ jobs:
             PR NUMBER: ${{ github.event.pull_request.number }}
 
             Please review this pull request and provide feedback on:
-            - Code quality and adherence to engineering standards (docs/ENGINEERING_STANDARDS.md)
-            - Python best practices (type hints, error handling, docstrings)
+            - Code quality and adherence to engineering standards (CONTRIBUTING.md)
+            - Shell script best practices (ShellCheck compliance, quoting, error handling)
+            - Module headers and documentation
+            - Platform detection and compatibility
             - Potential bugs or issues
             - Security concerns
-            - Test coverage
+            - Test coverage (bats tests)
+            - Performance considerations
 
             Be constructive and helpful in your feedback. Focus on substantive issues, not nitpicks.
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   claude-review:
+    timeout-minutes: 30
     # Only run on internal PRs (not from forks)
     if: github.event.pull_request.head.repo.full_name == github.repository
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -23,7 +23,6 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        continue-on-error: true  # Don't block PR if Claude fails
         uses: anthropics/claude-code-action@3a38b377b30c75102b420405ed9516b57ca2e248 # v1
         with:
           allowed_bots: "Copilot,copilot-swe-agent"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+**Tmux Plugin Bootstrap**:
+- `install.sh` now installs TPM (Tmux Plugin Manager) into `~/.tmux/plugins/tpm` if missing,
+  so the plugins declared in `tmux.conf` actually load (run `prefix + I` to install them)
+- Hardened the Solarized colorscheme source lines with `source -q` so a missing plugin no
+  longer errors on tmux startup
+
+**Tmux Session Persistence** (tmux-resurrect + tmux-continuum):
+- `@continuum-restore` — sessions auto-restore the next time you start tmux after a reboot
+- `@resurrect-capture-pane-contents` — pre-reboot scrollback is restored too
+- Restores windows, panes, layout, and per-pane working directories
+
+**Per-Pane Claude Code Resume** (`tmux-claude-resume/`):
+- After a reboot, each restored tmux pane resumes *its own* Claude Code conversation by
+  session ID — eliminating the same-directory collision that `claude --continue` suffers
+- A `SessionStart` hook records `pane → session_id`; a resurrect post-save hook rewrites each
+  claude pane's restore command to `claude <your-flags> --resume <id>` (or the `-r` picker if
+  the session is gone). Your launch flags (e.g. `--dangerously-skip-permissions`) are preserved
+- Idempotent installer wires the hook into `~/.claude/settings.json`; scripts deploy via
+  `dotfiles.yaml` to `~/.config/tmux-claude-resume/`
+- See `tmux-claude-resume/README.md` for setup and how it works
+
+**Development Infrastructure**:
+- Claude Code GitHub workflows (`claude-on-mention`, `claude-pr-review`)
+- `docs/ENGINEERING_STANDARDS.md` and `CONTRIBUTING.md`
+- bats test suites for the tmux persistence and Claude-resume features
+
 ### Changed
 
 **direnv Integration**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,12 +182,58 @@ To maintain performance:
 - Document any `eval` usage with clear comments
 - Be careful with file permissions when creating files
 
+## AI-Assisted Code Review
+
+This repository uses Claude Code for automated assistance and code review.
+
+### Automated PR Reviews
+
+When you open or update a PR, Claude will automatically review your changes against:
+- Code quality standards (this CONTRIBUTING.md file)
+- ShellCheck compliance
+- Module headers and documentation
+- Platform compatibility
+- Test coverage (bats tests)
+- Performance considerations
+
+**Note:** Claude's suggestions should be reviewed by human maintainers before merging. Automated reviews are advisory, not blocking.
+
+### Interactive Assistance
+
+Tag `@claude` in any issue, PR, or comment to get help with:
+- Code review requests
+- Bug investigation
+- Implementation questions
+- Documentation clarification
+- ShellCheck error explanations
+- Module design suggestions
+
+**Example:**
+```
+@claude can you help me understand why this ShellCheck warning is appearing?
+```
+
+Claude will respond with context-aware assistance based on the repository's code and standards.
+
+### Configuration
+
+The workflows require two secrets to be configured in the repository:
+- `CLAUDE_CODE_OAUTH_TOKEN`: For interactive Claude sessions (mentions)
+- `ANTHROPIC_API_KEY`: For automated PR reviews
+
+### Limitations
+
+- Claude cannot push code directly to `main` (repository rules apply)
+- Review suggestions are advisory and should be validated
+- Complex architectural decisions still require human review
+
 ## Getting Help
 
 - Check existing modules for examples
 - Run `shellcheck <file>` to catch common issues
 - Look at recent PRs for patterns
 - Ask questions in PR comments
+- Tag `@claude` for AI-assisted help
 
 ## Code Review Expectations
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,20 @@ Restart your terminal.
 - **Bash**: Fast startup, git-aware prompt, cross-platform completions
 - **Vim**: Modern config with vim-plug, Go/Ruby/JavaScript support
 - **Git**: Powerful aliases (fpush, reup, changelog, main sync)
-- **Tmux**: Vim keybindings, session persistence, Solarized colors
+- **Tmux**: Vim keybindings, TPM plugins, session persistence across reboot, per-pane Claude Code resume, Solarized colors
 - **Tools**: pyenv, direnv, fzf, volta integration
+
+### Tmux session persistence
+
+Tmux plugins are managed by [TPM](https://github.com/tmux-plugins/tpm), which `install.sh`
+bootstraps automatically — run `prefix + I` inside tmux once to install the declared plugins.
+With [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) +
+[tmux-continuum](https://github.com/tmux-plugins/tmux-continuum), your windows, panes, layout,
+working directories, and scrollback survive a reboot.
+
+If you run Claude Code in tmux panes, [`tmux-claude-resume/`](tmux-claude-resume/README.md)
+makes each restored pane resume **its own** conversation by session ID (no same-directory
+collision). See its README to enable it.
 
 ## Requirements
 

--- a/docs/ENGINEERING_STANDARDS.md
+++ b/docs/ENGINEERING_STANDARDS.md
@@ -1,0 +1,1238 @@
+# Engineering Standards
+
+> **Philosophy**: Write code that is a joy to read, trivial to test, and easy to extend.
+
+This document defines our organizational engineering standards. These principles apply to all projects and guide every technical decision we make.
+
+> **Note for AI Assistants**: This is the comprehensive human-facing version. For a concise, actionable AI-optimized version, see `.claude/docs/ENGINEERING_STANDARDS.md`. Both versions are intentionally maintained with different audiences in mind.
+
+---
+
+## Table of Contents
+
+1. [Core Principles](#core-principles)
+2. [Python Best Practices](#python-best-practices)
+3. [Code Style Guidelines](#code-style-guidelines)
+4. [Architecture Patterns](#architecture-patterns)
+5. [Testing Requirements](#testing-requirements)
+6. [Development Workflow](#development-workflow)
+7. [Documentation Standards](#documentation-standards)
+8. [Code Quality Tools](#code-quality-tools)
+
+---
+
+## Core Principles
+
+### 1. Simple > Complex
+
+**Choose straightforward solutions over clever ones.**
+
+```python
+# BAD: Clever but hard to understand
+result = reduce(lambda a,b: a+b, filter(lambda x: x%2, map(int, data.split())))
+
+# GOOD: Explicit and clear
+numbers = [int(x) for x in data.split()]
+odd_numbers = [n for n in numbers if n % 2 == 1]
+result = sum(odd_numbers)
+```
+
+**Why**: Code is read far more often than it's written. Clarity trumps cleverness.
+
+### 2. Explicit > Implicit
+
+**Make your intentions clear. No magic, no surprises.**
+
+```python
+# BAD: Implicit behavior
+def process_data(df, mode=1):
+    if mode == 1:
+        # ... (what does mode 1 do?)
+    elif mode == 2:
+        # ... (what about mode 2?)
+
+# GOOD: Explicit intent
+from enum import Enum
+
+class ProcessingMode(Enum):
+    NORMALIZE = "normalize"
+    VALIDATE = "validate"
+    TRANSFORM = "transform"
+
+def process_data(df: pd.DataFrame, mode: ProcessingMode) -> pd.DataFrame:
+    """Process dataframe based on specified mode."""
+    match mode:
+        case ProcessingMode.NORMALIZE:
+            return normalize_columns(df)
+        case ProcessingMode.VALIDATE:
+            return validate_schema(df)
+        case ProcessingMode.TRANSFORM:
+            return apply_transformations(df)
+```
+
+### 3. DRY (Don't Repeat Yourself)
+
+**Every piece of knowledge should have a single, authoritative representation.**
+
+```python
+# BAD: Logic duplicated
+def process_user_input(text):
+    return text.strip().lower().replace('_', '-')
+
+def process_file_name(filename):
+    return filename.strip().lower().replace('_', '-')
+
+def process_tag(tag):
+    return tag.strip().lower().replace('_', '-')
+
+# GOOD: Single source of truth
+def normalize_identifier(text: str) -> str:
+    """Normalize text: strip, lowercase, replace underscores."""
+    return text.strip().lower().replace('_', '-')
+
+# Use everywhere
+user_input = normalize_identifier(raw_input)
+filename = normalize_identifier(raw_filename)
+tag = normalize_identifier(raw_tag)
+```
+
+### 4. Convention Over Configuration
+
+**Sensible defaults that work out of the box. Configuration only when necessary.**
+
+```python
+# BAD: Everything requires configuration
+processor = DataProcessor(
+    encoding='utf-8',
+    date_format='%Y-%m-%d',
+    decimal_separator='.',
+    trim_whitespace=True,
+    log_level='INFO'
+)
+
+# GOOD: Smart defaults, configure only exceptions
+processor = DataProcessor()  # Works immediately
+processor_eu = DataProcessor(decimal_separator=',')  # Override when needed
+```
+
+### 5. Fail Fast
+
+**Detect errors early and fail immediately with clear messages.**
+
+```python
+# BAD: Silent failures or late errors
+def process_file(path):
+    try:
+        data = load_file(path)
+        return process_data(data)
+    except:
+        return None  # What went wrong?
+
+# GOOD: Explicit validation, clear errors
+def process_file(path: Path) -> ProcessedData:
+    """Process file at path. Raises ValueError if file invalid."""
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+
+    if not path.suffix == '.xlsx':
+        raise ValueError(f"Expected .xlsx file, got: {path.suffix}")
+
+    if path.stat().st_size > 100_000_000:  # 100MB
+        raise ValueError(f"File too large (>100MB): {path}")
+
+    return process_data(load_file(path))
+```
+
+### 6. YAGNI (You Aren't Gonna Need It)
+
+**Don't build features until you actually need them.**
+
+```python
+# BAD: Over-engineering for imaginary future
+class DataProcessor:
+    def process(
+        self,
+        data,
+        strategy='default',
+        use_ml=False,  # ML not implemented yet
+        cache=True,     # No cache exists yet
+        parallel=False, # Not needed yet
+        retry_count=3,  # Haven't hit failures yet
+        timeout=30      # No timeouts observed yet
+    ):
+        ...
+
+# GOOD: Build what you need now
+class DataProcessor:
+    def process(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Process dataframe using current validated approach."""
+        return self._apply_transformations(data)
+
+# Add features later when:
+# - ML: When we have training data and proof it helps
+# - Caching: When profiling shows it's a bottleneck
+# - Parallelization: When single-threaded is too slow
+```
+
+### 7. File Size Limit: 500 Lines
+
+**If a file exceeds 500 lines, it's doing too much. Split it.**
+
+**Strategies**:
+- Extract helper functions to utilities
+- Split large classes into smaller, focused classes
+- Move constants to configuration files
+- Use composition over inheritance
+- Create submodules when a module grows
+
+```python
+# If models/participant.py grows too large:
+models/participant/
+├── __init__.py         # Re-export main classes
+├── participant.py      # Core Participant model (< 500 lines)
+├── matching.py         # Matching-related methods
+└── validation.py       # Validation logic
+```
+
+---
+
+## Python Best Practices
+
+### ⚠️ CRITICAL: Virtual Environments - ALWAYS Required
+
+**ALWAYS use virtual environments. NEVER modify or install packages to system/global Python. No exceptions.**
+
+This is a non-negotiable organizational standard that applies to:
+- ✅ All Python development work
+- ✅ Running scripts or tools
+- ✅ Installing any Python packages
+- ✅ Humans and AI assistants alike
+
+**PROHIBITED: Global Package Installation**
+```bash
+# ❌ NEVER DO THIS - Modifies system Python
+pip install click
+python3 -m pip install --user rich
+sudo pip install anything
+
+# These commands are BANNED in our organization
+```
+
+**REQUIRED: Virtual Environment Usage**
+```bash
+# ✅ ALWAYS DO THIS - Isolated, safe, reproducible
+python3 -m venv .venv
+source .venv/bin/activate  # macOS/Linux
+.venv\Scripts\activate     # Windows
+
+# Now safe to install
+pip install -r requirements.txt
+
+# Verify you're in venv
+which python  # Should show .venv/bin/python
+python --version
+
+# Deactivate when done
+deactivate
+```
+
+**Why Virtual Environments**:
+- ✅ Dependency isolation - no conflicts between projects
+- ✅ Reproducibility - everyone uses same package versions
+- ✅ Protects user's system Python from corruption
+- ✅ Easy cleanup - delete `.venv/` to start fresh
+- ✅ Required by modern Python - PEP 668 externally-managed-environment
+- ✅ Prevents "functions on my machine" issues
+
+**For AI Assistants**:
+- **NEVER** run `pip install` without first verifying a virtual environment is active
+- **NEVER** use `--user` flag or `sudo pip`
+- **ALWAYS** check `which python` shows `.venv/bin/python` before installing packages
+- **ALWAYS** use `.venv/bin/python` explicitly when running Python commands
+- If no virtual environment exists, create one first, then activate it, then install
+
+### Modern Python Packaging
+
+Use `pyproject.toml` (PEP 621) for dependency management:
+
+```toml
+[project]
+name = "my-project"
+version = "0.1.0"
+description = "Project description"
+requires-python = ">=3.11"
+dependencies = [
+    "pandas>=2.0.0",
+    "pydantic>=2.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "ruff>=0.1.0",
+    "mypy>=1.5.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+```
+
+Install in editable mode:
+```bash
+pip install -e ".[dev]"
+```
+
+### Type Hints - Required
+
+**All functions must have type hints.**
+
+```python
+from typing import Protocol
+from datetime import date
+from pathlib import Path
+import pandas as pd
+
+# Type aliases for clarity
+UserID = str
+ConfidenceLevel = Literal['HIGH', 'MEDIUM', 'LOW']
+
+# Function signatures with types
+def process_data(
+    data: pd.DataFrame,
+    user_id: UserID,
+    threshold: float = 0.8
+) -> tuple[pd.DataFrame, list[str]]:
+    """
+    Process dataframe for user.
+
+    Returns:
+        Tuple of (processed_data, errors)
+    """
+    ...
+
+# Data classes with types
+@dataclass
+class User:
+    id: UserID
+    name: str
+    email: str
+    created_at: date
+    is_active: bool = True
+
+# Protocols for interfaces (duck typing with type checking)
+class Processor(Protocol):
+    """Interface for data processors."""
+
+    def process(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Process dataframe and return result."""
+        ...
+```
+
+**Benefits**:
+- IDE autocomplete and inline documentation
+- Catch errors before runtime (mypy in CI/CD)
+- Self-documenting code
+- Easier refactoring
+
+### Error Handling - Explicit Only
+
+**Only catch exceptions you expect and can handle.**
+
+```python
+# BAD: Catching everything hides bugs
+def get_value(data, key):
+    try:
+        return data[key]
+    except:  # Catches typos in YOUR code too!
+        return None
+
+# BAD: Catching exceptions you don't expect
+def parse_file(path):
+    try:
+        df = pd.read_excel(path)
+        return process_dataframe(df)
+    except Exception as e:  # What exception? We don't know!
+        logger.error(f"Something went wrong: {e}")
+        return None
+
+# GOOD: Explicit checks, no exception handling needed
+def get_value(data: dict, key: str) -> str:
+    if key not in data:
+        raise KeyError(f"Required key '{key}' not found. Available: {list(data.keys())}")
+    return data[key]
+
+# GOOD: Only catch specific, expected exceptions
+def parse_file(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+
+    # We KNOW BadZipFile can happen with corrupt Excel files
+    try:
+        df = pd.read_excel(path)
+    except BadZipFile as e:
+        raise ValueError(f"Corrupt Excel file: {path}") from e
+
+    # Let other exceptions bubble up - we don't expect them
+    return process_dataframe(df)
+```
+
+**When to Use Try/Except**:
+- ✅ File operations (FileNotFoundError expected)
+- ✅ External API calls (network errors expected)
+- ✅ Parsing user input (ValueError expected)
+- ❌ Regular Python logic (if catching IndexError, your code has a bug)
+- ❌ "Just in case" (if you don't know what exception could occur, don't catch it)
+
+### Logging - Structured and Contextual
+
+**Always use structured logging. Never use `print()`.**
+
+```python
+import structlog
+
+logger = structlog.get_logger()
+
+def process_batch(batch_id: str, items: list[Item]) -> BatchResult:
+    logger.info(
+        "batch_processing_started",
+        batch_id=batch_id,
+        item_count=len(items)
+    )
+
+    results = []
+    errors = []
+
+    for item in items:
+        try:
+            result = process_item(item)
+            results.append(result)
+            logger.debug(
+                "item_processed",
+                batch_id=batch_id,
+                item_id=item.id,
+                status="success"
+            )
+        except ValidationError as e:
+            errors.append((item.id, str(e)))
+            logger.warning(
+                "item_validation_failed",
+                batch_id=batch_id,
+                item_id=item.id,
+                error=str(e)
+            )
+
+    logger.info(
+        "batch_processing_completed",
+        batch_id=batch_id,
+        success_count=len(results),
+        error_count=len(errors)
+    )
+
+    return BatchResult(results, errors)
+```
+
+**Benefits**:
+- Structured data for easy querying (JSON logs)
+- Consistent format across codebase
+- Easy to aggregate and analyze
+- Context preserved (batch_id, item_id, etc.)
+
+---
+
+## Code Style Guidelines
+
+### Python Style
+
+- **Line length**: 100 characters max
+- **Formatter**: Ruff (replaces Black, isort, etc.)
+- **Type checker**: mypy with `--strict`
+- **Docstrings**: Google-style for all public functions and classes
+
+### Concise and Elegant Code
+
+**Every line should earn its place.**
+
+```python
+# BAD: Verbose and unclear
+def get_full_name(first_name, middle_name, last_name):
+    if middle_name is not None and middle_name != '':
+        full_name = first_name + ' ' + middle_name + ' ' + last_name
+    else:
+        full_name = first_name + ' ' + last_name
+    return full_name
+
+# GOOD: Pythonic with filter
+def get_full_name(first: str, middle: str | None, last: str) -> str:
+    """Return full name, including middle if present."""
+    return ' '.join(filter(None, [first, middle, last]))
+```
+
+**Guidelines**:
+- Prefer comprehensions over loops when clearer
+- Use built-in functions (`filter`, `map`, `any`, `all`)
+- Avoid deep nesting (max 3 levels)
+- Extract complex conditions into named variables
+- One logical operation per line
+
+**Example - List Comprehension**:
+```python
+# BAD
+high_confidence_items = []
+for item in items:
+    if item.confidence == 'HIGH':
+        high_confidence_items.append(item)
+
+# GOOD
+high_confidence_items = [item for item in items if item.confidence == 'HIGH']
+```
+
+### Naming Conventions
+
+```python
+# Constants - UPPER_SNAKE_CASE
+MAX_RETRY_COUNT = 3
+DEFAULT_TIMEOUT_SECONDS = 30
+
+# Functions and variables - snake_case
+def calculate_total_price(items: list[Item]) -> Decimal:
+    total_price = sum(item.price for item in items)
+    return total_price
+
+# Classes - PascalCase
+class DataProcessor:
+    pass
+
+class UserAccount:
+    pass
+
+# Private methods/attributes - leading underscore
+class MyClass:
+    def _internal_helper(self):
+        pass
+
+    def public_method(self):
+        self._internal_helper()
+
+# Type aliases - PascalCase
+UserID = str
+ProcessingMode = Literal['FAST', 'THOROUGH']
+```
+
+---
+
+## Architecture Patterns
+
+### Separation of Concerns
+
+**Each module, class, and function should have one clear responsibility.**
+
+```
+src/myproject/
+├── parsers/           # Read and parse files
+│   ├── excel_parser.py
+│   ├── csv_parser.py
+│   └── base_parser.py
+├── validators/        # Validate data quality
+│   ├── schema_validator.py
+│   └── business_rules.py
+├── processors/        # Transform and process data
+│   ├── normalizer.py
+│   └── aggregator.py
+├── exporters/         # Export to various formats
+│   └── excel_exporter.py
+├── models/            # Data models (Pydantic)
+│   ├── user.py
+│   └── transaction.py
+├── services/          # Business logic orchestration
+│   └── processing_service.py
+├── config/            # Configuration loading
+│   └── settings.py
+└── utils/             # Shared utilities
+    ├── date_utils.py
+    └── text_utils.py
+```
+
+**Each function does ONE thing**:
+```python
+def read_excel_file(path: Path) -> pd.DataFrame:
+    """Read Excel file and return raw DataFrame."""
+    # Only file I/O, no parsing logic
+
+def detect_header_row(df: pd.DataFrame) -> int:
+    """Find the row number where headers start."""
+    # Only header detection, no data extraction
+
+def extract_data_rows(df: pd.DataFrame, header_row: int) -> pd.DataFrame:
+    """Extract data rows after header."""
+    # Only data extraction, no normalization
+
+def normalize_column_names(df: pd.DataFrame, mapping: dict) -> pd.DataFrame:
+    """Standardize column names using mapping."""
+    # Only column renaming, no data transformation
+```
+
+### Dependency Injection
+
+**Don't create dependencies inside; inject them from outside.**
+
+```python
+# BAD: Hard-coded dependencies
+class ProcessingService:
+    def __init__(self):
+        self.parser = DataParser()  # Can't swap implementations
+        self.validator = DataValidator()
+
+# GOOD: Dependencies injected
+class ProcessingService:
+    def __init__(
+        self,
+        parser: DataParser,
+        validator: DataValidator,
+    ):
+        self.parser = parser
+        self.validator = validator
+
+# Easy to test with mocks
+def test_processing_service():
+    mock_parser = Mock(spec=DataParser)
+    mock_validator = Mock(spec=DataValidator)
+    service = ProcessingService(mock_parser, mock_validator)
+    # Test service behavior with controlled dependencies
+```
+
+**Benefits**:
+- Makes testing trivial (inject mocks)
+- Easy to swap implementations
+- Dependencies are explicit and clear
+
+### Composition Over Inheritance
+
+**Build complex behavior by combining simple objects, not deep inheritance.**
+
+```python
+# BAD: Deep inheritance hierarchy
+class BaseParser:
+    def parse(self): ...
+
+class ExcelParser(BaseParser):
+    def read_excel(self): ...
+
+class SpecializedParser(ExcelParser):
+    def parse_specialized(self): ...
+
+class SpecializedValidatingParser(SpecializedParser):
+    def validate(self): ...
+
+# GOOD: Composition
+class ExcelReader:
+    def read(self, path: Path) -> pd.DataFrame: ...
+
+class ColumnMapper:
+    def map_columns(self, df: pd.DataFrame, mapping: dict) -> pd.DataFrame: ...
+
+class DataValidator:
+    def validate(self, df: pd.DataFrame) -> list[str]: ...
+
+class SpecializedParser:
+    def __init__(
+        self,
+        reader: ExcelReader,
+        mapper: ColumnMapper,
+        validator: DataValidator
+    ):
+        self.reader = reader
+        self.mapper = mapper
+        self.validator = validator
+
+    def parse(self, path: Path) -> pd.DataFrame:
+        df = self.reader.read(path)
+        df = self.mapper.map_columns(df, SPECIALIZED_MAPPING)
+        errors = self.validator.validate(df)
+        if errors:
+            raise ValidationError(errors)
+        return df
+```
+
+### Immutability Where Possible
+
+**Prefer immutable data structures to reduce bugs.**
+
+```python
+# Immutable data classes
+@dataclass(frozen=True)  # Immutable
+class User:
+    id: str
+    name: str
+    email: str
+
+# Pure functions (no side effects)
+def normalize_name(name: str) -> str:
+    """Return normalized name without modifying input."""
+    return name.strip().upper()
+
+# Return new DataFrame instead of mutating
+def add_calculated_column(df: pd.DataFrame) -> pd.DataFrame:
+    """Return new DataFrame with calculated column added."""
+    return df.assign(
+        total_price=df['quantity'] * df['unit_price']
+    )
+```
+
+### Interface Segregation (Protocols)
+
+**Keep interfaces focused. Clients shouldn't depend on methods they don't use.**
+
+```python
+from typing import Protocol
+
+# BAD: Fat interface
+class DataProcessor(Protocol):
+    def parse(self, path: Path): ...
+    def validate(self, df: pd.DataFrame): ...
+    def normalize(self, df: pd.DataFrame): ...
+    def export(self, df: pd.DataFrame, path: Path): ...
+    # User must implement ALL methods even if they only need parse()
+
+# GOOD: Focused interfaces
+class Parseable(Protocol):
+    def parse(self, path: Path) -> pd.DataFrame: ...
+
+class Validatable(Protocol):
+    def validate(self, df: pd.DataFrame) -> list[str]: ...
+
+class Exportable(Protocol):
+    def export(self, df: pd.DataFrame, path: Path) -> None: ...
+
+# Implement only what you need
+class MyParser:
+    def parse(self, path: Path) -> pd.DataFrame:
+        return pd.read_excel(path)
+    # Don't need validate or export
+```
+
+**Protocols vs Abstract Base Classes**:
+- Protocols: Structural typing (duck typing with type checking)
+- No inheritance needed - just implement the methods
+- More flexible and Pythonic
+
+```python
+# With Protocol - no inheritance needed
+class Processor(Protocol):
+    def process(self, data: pd.DataFrame) -> pd.DataFrame: ...
+
+class MyProcessor:  # No inheritance!
+    def process(self, data: pd.DataFrame) -> pd.DataFrame:
+        return data * 2
+
+# MyProcessor matches the Processor protocol automatically!
+def run_processor(processor: Processor, data: pd.DataFrame):
+    return processor.process(data)
+
+run_processor(MyProcessor(), df)  # ✅ Works - type checker validates
+```
+
+---
+
+## Testing Requirements
+
+### Test Structure
+
+```
+tests/
+├── __init__.py
+├── conftest.py         # Pytest fixtures
+├── unit/               # Unit tests mirror src structure
+│   ├── test_parsers.py
+│   └── test_validators.py
+├── integration/        # Integration tests
+│   └── test_workflows.py
+└── fixtures/           # Test data
+    └── sample_data.xlsx
+```
+
+### Test Types
+
+1. **Unit Tests** (`tests/unit/`) - Fast, isolated, mocked dependencies
+2. **Integration Tests** (`tests/integration/`) - Multi-component workflows
+3. **E2E Tests** (`tests/e2e/`) - Full system with real external services
+
+### Unit Test Example
+
+```python
+import pytest
+from unittest.mock import Mock
+from myproject.services import ProcessingService
+
+@pytest.fixture
+def mock_parser():
+    """Mock parser that returns sample data."""
+    parser = Mock()
+    parser.parse.return_value = pd.DataFrame({
+        'name': ['Alice', 'Bob'],
+        'age': [30, 25]
+    })
+    return parser
+
+@pytest.fixture
+def mock_validator():
+    """Mock validator that always passes."""
+    validator = Mock()
+    validator.validate.return_value = []  # No errors
+    return validator
+
+def test_processing_service_success(mock_parser, mock_validator):
+    """Test processing service with valid data."""
+    service = ProcessingService(mock_parser, mock_validator)
+
+    result = service.process(Path('test.xlsx'))
+
+    assert len(result) == 2
+    assert result['name'].tolist() == ['Alice', 'Bob']
+    mock_parser.parse.assert_called_once()
+    mock_validator.validate.assert_called_once()
+
+def test_processing_service_validation_failure(mock_parser, mock_validator):
+    """Test processing service with validation errors."""
+    mock_validator.validate.return_value = ['Missing required column']
+
+    service = ProcessingService(mock_parser, mock_validator)
+
+    with pytest.raises(ValidationError, match='Missing required column'):
+        service.process(Path('test.xlsx'))
+```
+
+### Test Quality Guidelines
+
+- Test behavior, not implementation
+- One assertion per test (generally)
+- Use descriptive test names: `test_<what>_<when>_<expected>`
+- Use fixtures for common setup
+- Mock external dependencies (APIs, databases, file I/O)
+- Aim for >80% code coverage
+
+### Running Tests
+
+```bash
+# Run all tests
+pytest tests/ -v
+
+# Run specific test file
+pytest tests/unit/test_parsers.py -v
+
+# Run with coverage
+pytest tests/ --cov=src --cov-report=term-missing
+
+# Run only unit tests (skip slow e2e)
+pytest tests/unit/ -v
+
+# Run only marked tests
+pytest -m "not e2e"  # Skip e2e tests
+pytest -m e2e        # Run only e2e tests
+```
+
+---
+
+## Development Workflow
+
+### ⚠️ CRITICAL: Pull Request Requirement
+
+**ALWAYS use pull requests. NEVER push directly to the default branch (main/master). No exceptions.**
+
+This is a non-negotiable organizational standard that applies to:
+- ✅ All code changes, no matter how small
+- ✅ Documentation updates, even one-line fixes
+- ✅ Configuration changes
+- ✅ Everything
+
+**Why this matters:**
+- Enables code review and quality checks
+- Prevents accidental breakage of main branch
+- Creates audit trail of all changes
+- Allows CI/CD to validate changes before merge
+- Facilitates collaboration and knowledge sharing
+
+**The only way to change the default branch:**
+1. Create a feature branch
+2. Make your changes on the branch
+3. Push the feature branch to remote
+4. Create a pull request
+5. Wait for review and CI checks
+6. Merge the PR (never force push or bypass)
+
+**If you accidentally push to main:**
+1. Immediately revert the commit
+2. Create a feature branch from that commit
+3. Create a PR with the changes
+4. Merge through proper process
+
+### Daily Development
+
+```bash
+# 1. Activate virtual environment
+source .venv/bin/activate
+
+# 2. Create feature branch
+git checkout -b feature/my-feature
+
+# 3. Make changes
+
+# 4. Run tests
+pytest tests/ -v
+
+# 5. Check linting
+ruff check --fix src/ tests/
+
+# 6. Format code
+ruff format src/ tests/
+
+# 7. Type check
+mypy src/
+
+# 8. Commit changes
+git add .
+git commit -m "feat: add my feature"
+
+# 9. Push and create PR
+git push -u origin feature/my-feature
+```
+
+### Pre-Commit Hooks
+
+Install pre-commit to run checks automatically:
+
+```bash
+# Install pre-commit
+pip install pre-commit
+
+# Install hooks
+pre-commit install
+
+# Now hooks run automatically on git commit!
+```
+
+**What runs on commit**:
+- Ruff linting and formatting
+- mypy type checking
+- File size limit enforcement (500 lines)
+- Trailing whitespace removal
+- YAML validation
+- Large file check
+
+### Code Review Checklist
+
+When reviewing code, check for:
+
+- [ ] Type hints on all functions
+- [ ] Tests for new functionality
+- [ ] Structured logging (no print statements)
+- [ ] File size under 500 lines
+- [ ] Proper error handling (specific exceptions only)
+- [ ] Consistent with existing code patterns
+- [ ] Documentation updated if needed
+- [ ] No hard-coded configuration
+- [ ] Dependencies injected, not created
+- [ ] Functions do one thing only
+
+---
+
+## Documentation Standards
+
+### Documentation as Code
+
+**Documentation lives with code, in code. Not in separate wikis.**
+
+### Docstrings - Google Style
+
+```python
+def process_data(
+    data: pd.DataFrame,
+    threshold: float = 0.8,
+    mode: ProcessingMode = ProcessingMode.NORMALIZE
+) -> tuple[pd.DataFrame, list[str]]:
+    """
+    Process dataframe with specified threshold and mode.
+
+    Applies normalization, validation, and transformation based on mode.
+    Returns both processed data and any validation errors encountered.
+
+    Args:
+        data: Input dataframe with raw data
+        threshold: Confidence threshold for filtering (0.0 to 1.0)
+        mode: Processing mode - NORMALIZE, VALIDATE, or TRANSFORM
+
+    Returns:
+        Tuple of (processed_dataframe, error_messages)
+
+    Raises:
+        ValueError: If threshold not in range [0.0, 1.0]
+        KeyError: If required columns missing from dataframe
+
+    Example:
+        >>> df = pd.DataFrame({'value': [1, 2, 3]})
+        >>> result, errors = process_data(df, threshold=0.9)
+        >>> print(f"Processed {len(result)} rows, {len(errors)} errors")
+        Processed 3 rows, 0 errors
+    """
+    if not 0.0 <= threshold <= 1.0:
+        raise ValueError(f"Threshold must be in [0.0, 1.0], got {threshold}")
+
+    # Implementation...
+```
+
+### Type Hints as Documentation
+
+```python
+from typing import TypedDict, Literal
+
+# Type aliases document domain concepts
+UserID = str
+ConfidenceLevel = Literal['HIGH', 'MEDIUM', 'LOW']
+
+# TypedDict documents data structures
+class ProcessingResult(TypedDict):
+    """
+    Result of data processing operation.
+
+    Attributes:
+        success: Whether processing completed successfully
+        rows_processed: Number of rows processed
+        errors: List of error messages encountered
+        confidence: Overall confidence level of results
+    """
+    success: bool
+    rows_processed: int
+    errors: list[str]
+    confidence: ConfidenceLevel
+```
+
+### README Structure
+
+Every project should have a comprehensive README:
+
+```markdown
+# Project Name
+
+Brief description (1-2 sentences)
+
+## Quick Start
+
+```bash
+# Setup
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+
+# Run tests
+pytest tests/
+
+# Run application
+python -m myproject
+```
+
+## Development
+
+See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)
+
+## Architecture
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md)
+```
+
+### ADRs (Architecture Decision Records)
+
+Document significant decisions in `adr/` directory:
+
+```markdown
+# ADR-001: Use Pydantic for Data Validation
+
+**Status**: Accepted
+
+**Context**:
+We need robust data validation for user input and external APIs.
+
+**Decision**:
+Use Pydantic v2 for all data validation and settings management.
+
+**Consequences**:
+- Automatic validation on model instantiation
+- Better error messages for users
+- Type hints become runtime validation
+- Integrates well with FastAPI if we build an API
+
+**Alternatives Considered**:
+- Marshmallow: More boilerplate, less Pythonic
+- Cerberus: Less type-safe
+- Manual validation: Error-prone, not DRY
+```
+
+---
+
+## Code Quality Tools
+
+### Ruff - All-in-One Linter + Formatter
+
+**Why Ruff?**
+- 10-100x faster than existing tools (written in Rust)
+- Replaces Black, Flake8, isort, and more
+- Used by Pandas, FastAPI, Pydantic
+
+**Configuration** (`pyproject.toml`):
+```toml
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort (import sorting)
+    "N",   # pep8-naming
+    "UP",  # pyupgrade (modernize syntax)
+    "B",   # bugbear (common bugs)
+    "C4",  # comprehensions
+    "SIM", # simplify
+]
+
+ignore = [
+    "E501",  # Line too long (formatter handles it)
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+```
+
+**Usage**:
+```bash
+# Lint and auto-fix
+ruff check --fix .
+
+# Format code
+ruff format .
+
+# Both in one command
+ruff check --fix . && ruff format .
+```
+
+### mypy - Type Checking
+
+**Configuration** (`pyproject.toml`):
+```toml
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+```
+
+**Usage**:
+```bash
+# Type check entire src
+mypy src/
+
+# Type check specific file
+mypy src/myproject/parser.py
+```
+
+### pytest - Testing
+
+**Configuration** (`pyproject.toml`):
+```toml
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "-v",
+    "--strict-markers",
+    "--tb=short",
+]
+markers = [
+    "e2e: end-to-end tests (may be slow)",
+    "unit: fast unit tests",
+]
+```
+
+### Pre-commit Configuration
+
+`.pre-commit-config.yaml`:
+```yaml
+repos:
+  # Ruff - linting and formatting
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.9
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  # Type checking
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.7.1
+    hooks:
+      - id: mypy
+        additional_dependencies: [pydantic>=2.0]
+        args: [--strict]
+
+  # File size limit
+  - repo: local
+    hooks:
+      - id: file-size-check
+        name: Check file size < 500 lines
+        entry: python scripts/check_file_size.py
+        language: python
+        types: [python]
+
+  # Standard checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+        args: [--maxkb=1000]
+```
+
+---
+
+## Summary
+
+These standards ensure our code is:
+
+- **Readable**: Clear intent, minimal cognitive load
+- **Maintainable**: Easy to modify without breaking things
+- **Testable**: Isolated components, dependency injection
+- **Robust**: Fail fast, validate early, log everything
+- **Scalable**: Separation of concerns, composition, focused interfaces
+
+### Before Writing Code, Ask:
+
+1. Is this the simplest solution that works?
+2. Can this logic be reused elsewhere?
+3. Will this be obvious to someone reading it in 6 months?
+4. Can we test this easily?
+5. Does this follow our conventions?
+
+### Our Tech Stack (Python):
+
+- **Python 3.11+** (latest stable)
+- **Pydantic** (data validation)
+- **Protocols** (structural typing)
+- **Ruff** (linting + formatting)
+- **mypy** (type checking)
+- **pytest** (testing)
+- **pre-commit** (automated quality checks)
+
+---
+
+**Status**: These standards apply to all organizational projects. They will be synced via the Claude Code automation sync tool to ensure consistency across the organization.

--- a/docs/superpowers/plans/2026-06-07-tmux-session-persistence.md
+++ b/docs/superpowers/plans/2026-06-07-tmux-session-persistence.md
@@ -1,3 +1,17 @@
+---
+validated:
+  sha: 5468123758741fe40418f9f9ab8601ed92bf244a
+  date: 2026-06-08T03:32:45Z
+  reviewers: [fact-check, solid-hygiene]
+  findings:
+    critical: 0
+    important: 0
+    medium: 0
+    low: 2
+    nitpick: 0
+  net_negative_remaining: 0
+---
+
 # tmux Session Persistence Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
@@ -17,7 +31,7 @@
 ## File Structure
 
 - **Modify:** `tmux/tmux.conf` — add a "session persistence" block (3 option lines + 1 comment) immediately after the last `set -g @plugin` line (line 53) and before the `# Initialize TMUX plugin manager` comment (line 55). This is the only repo source change.
-- **Create:** `tests/test-tmux-persistence.bats` — bats test asserting the persistence options are set when the config is sourced. Follows the existing `tests/*.bats` convention.
+- **Create:** `tests/test-tmux-persistence.bats` — bats test asserting the persistence options are set when the config is sourced. Mirrors the existing `tests/*.bats` structure (`setup`/`teardown`, `@test` blocks) but derives `DOTFILES_DIR` with a single `..` so it resolves to the repo root — deliberately diverging from the existing three bats files, whose `$(dirname "$BATS_TEST_DIRNAME")/..` form resolves one level *above* the repo. *(Verified 2026-06-07: was incorrect — the new test does not match the existing `DOTFILES_DIR` derivation; it intentionally uses the correct single-`..` form.)*
 
 No new scripts, no hook files: per the spec's Design note (2026-06-07), the Claude-restore behavior has exactly **one** owner — the inline `@resurrect-processes` rule. The post-restore-hook alternative from the spec's fallback ladder is deliberately NOT built unless Task 4 proves the inline rule cannot match (documented limitation, not a second owner).
 
@@ -39,6 +53,8 @@ Create `tests/test-tmux-persistence.bats`:
 # Description: Assert resurrect/continuum persistence options are set by tmux.conf
 
 setup() {
+    # NOTE: single '..' resolves to the repo root. The existing tests/*.bats use
+    # $(dirname "$BATS_TEST_DIRNAME")/.. which resolves ABOVE the repo — do not copy that form here.
     export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     export TMUX_CONF="$DOTFILES_DIR/tmux/tmux.conf"
     export SOCKET="tmux-persistence-test-$$"

--- a/docs/superpowers/plans/2026-06-07-tmux-session-persistence.md
+++ b/docs/superpowers/plans/2026-06-07-tmux-session-persistence.md
@@ -1,0 +1,312 @@
+# tmux Session Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make tmux sessions (windows, panes, layout, working directories, scrollback) survive a machine reboot, with Claude Code panes resuming their conversation via `claude --continue`.
+
+**Architecture:** Activate the already-declared-but-unconfigured `tmux-resurrect` + `tmux-continuum` plugins by adding a small block of `set -g @...` options to `tmux/tmux.conf` before the TPM `run` line. continuum auto-saves periodically and auto-restores on the next tmux launch (no launchd boot agent). Claude panes are relaunched via a single inline `@resurrect-processes` rule whose match string is tuned empirically to the real captured command line.
+
+**Tech Stack:** tmux 3.3a, TPM (already bootstrapped), tmux-resurrect, tmux-continuum, bats (test harness).
+
+**Spec:** `docs/superpowers/specs/2026-06-07-tmux-session-persistence-design.md` (blessed).
+
+**Branch note:** This work depends on the TPM bootstrap in PR #31. Decide at execution start whether to stack on `ccc-config-1` or branch fresh off `main` after #31 merges. The commit steps below are branch-agnostic.
+
+---
+
+## File Structure
+
+- **Modify:** `tmux/tmux.conf` — add a "session persistence" block (3 option lines + 1 comment) immediately after the last `set -g @plugin` line (line 53) and before the `# Initialize TMUX plugin manager` comment (line 55). This is the only repo source change.
+- **Create:** `tests/test-tmux-persistence.bats` — bats test asserting the persistence options are set when the config is sourced. Follows the existing `tests/*.bats` convention.
+
+No new scripts, no hook files: per the spec's Design note (2026-06-07), the Claude-restore behavior has exactly **one** owner — the inline `@resurrect-processes` rule. The post-restore-hook alternative from the spec's fallback ladder is deliberately NOT built unless Task 4 proves the inline rule cannot match (documented limitation, not a second owner).
+
+---
+
+### Task 1: Add core persistence options + failing test
+
+**Files:**
+- Create: `tests/test-tmux-persistence.bats`
+- Modify: `tmux/tmux.conf` (insert after line 53)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test-tmux-persistence.bats`:
+
+```bash
+#!/usr/bin/env bats
+# Test: tmux session persistence
+# Description: Assert resurrect/continuum persistence options are set by tmux.conf
+
+setup() {
+    export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export TMUX_CONF="$DOTFILES_DIR/tmux/tmux.conf"
+    export SOCKET="tmux-persistence-test-$$"
+    # Unset ITERM_PROFILE so the solarized if-shell source lines are skipped.
+    unset ITERM_PROFILE
+    tmux -L "$SOCKET" kill-server 2>/dev/null || true
+    tmux -L "$SOCKET" new-session -d -x 200 -y 50
+    tmux -L "$SOCKET" source-file "$TMUX_CONF"
+}
+
+teardown() {
+    tmux -L "$SOCKET" kill-server 2>/dev/null || true
+}
+
+@test "continuum auto-restore is enabled" {
+    run tmux -L "$SOCKET" show-options -gv @continuum-restore
+    [ "$status" -eq 0 ]
+    [ "$output" = "on" ]
+}
+
+@test "resurrect captures pane contents" {
+    run tmux -L "$SOCKET" show-options -gv @resurrect-capture-pane-contents
+    [ "$status" -eq 0 ]
+    [ "$output" = "on" ]
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bats tests/test-tmux-persistence.bats`
+Expected: Both tests FAIL — `show-options -gv @continuum-restore` exits non-zero / empty because the option isn't set yet.
+
+- [ ] **Step 3: Add the persistence block to tmux.conf**
+
+In `tmux/tmux.conf`, insert these lines immediately after `set -g @plugin 'seebi/tmux-colors-solarized'` (line 53) and before the blank line preceding `# Initialize TMUX plugin manager`:
+
+```tmux
+
+# --- session persistence (resurrect + continuum) ---
+set -g @continuum-restore 'on'                 # auto-restore sessions when tmux next starts
+set -g @resurrect-capture-pane-contents 'on'   # snapshot scrollback so the pre-reboot screen is readable
+```
+
+(The `@resurrect-processes` claude rule is added in Task 4 once its match string is known.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bats tests/test-tmux-persistence.bats`
+Expected: Both tests PASS.
+
+- [ ] **Step 5: Run the full bats suite to confirm no regressions**
+
+Run: `bats tests/`
+Expected: All tests pass (existing baseline/benchmark/validate suites unaffected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tmux/tmux.conf tests/test-tmux-persistence.bats
+git commit -m "feat(tmux): enable continuum restore + resurrect pane-contents capture"
+```
+
+---
+
+### Task 2: Install the plugins and verify they load
+
+This task touches only the local machine (no repo change, no commit). TPM was bootstrapped already (`~/.tmux/plugins/tpm` exists).
+
+**Files:** none (environment setup + verification).
+
+- [ ] **Step 1: Install all declared TPM plugins headlessly**
+
+Run: `~/.tmux/plugins/tpm/bin/install_plugins`
+Expected: Output lines cloning `tmux-resurrect`, `tmux-continuum`, `tmux-sensible`, `tmux-yank`, `tmux-prefix-highlight`, `tmux-colors-solarized`, ending with `TMUX environment reloaded.` or `Done.`
+
+- [ ] **Step 2: Verify resurrect and continuum are installed**
+
+Run: `ls -d ~/.tmux/plugins/tmux-resurrect ~/.tmux/plugins/tmux-continuum`
+Expected: Both directories exist (no "No such file or directory").
+
+- [ ] **Step 3: Verify the resurrect save script exists (needed by Task 3 & 4)**
+
+Run: `ls ~/.tmux/plugins/tmux-resurrect/scripts/save.sh ~/.tmux/plugins/tmux-resurrect/scripts/restore.sh`
+Expected: Both scripts listed.
+
+- [ ] **Step 4: Confirm the plugins actually load in a real tmux server**
+
+Run:
+```bash
+tmux -L loadcheck kill-server 2>/dev/null; tmux -L loadcheck new-session -d
+tmux -L loadcheck source-file ~/dotfiles/tmux/tmux.conf
+tmux -L loadcheck show-options -gv @continuum-restore
+tmux -L loadcheck show-hooks -g | grep -i continuum || echo "no continuum hook yet (expected before first interval)"
+tmux -L loadcheck kill-server 2>/dev/null
+```
+Expected: `@continuum-restore` prints `on`; no errors sourcing the config.
+
+---
+
+### Task 3: Verify baseline save/restore (layout + cwd + scrollback)
+
+Prove the core "survive a reboot" behavior — windows, panes, and working directories come back — using resurrect's own save/restore scripts on a throwaway socket (a `kill-server` stands in for the reboot).
+
+**Files:** none (verification only; no commit).
+
+- [ ] **Step 1: Build a known multi-window session on a test socket**
+
+Run:
+```bash
+S=persist-e2e
+tmux -L "$S" kill-server 2>/dev/null
+tmux -L "$S" new-session -d -s main -c /tmp
+tmux -L "$S" new-window -t main -c /usr/local
+tmux -L "$S" new-window -t main -c "$HOME"
+tmux -L "$S" source-file ~/dotfiles/tmux/tmux.conf
+tmux -L "$S" list-windows -a -F '#{window_index} #{pane_current_path}'
+```
+Expected: three windows listed with paths `/tmp`, `/usr/local`, and your home dir.
+
+- [ ] **Step 2: Save session state with resurrect**
+
+Run: `tmux -L "$S" run-shell ~/.tmux/plugins/tmux-resurrect/scripts/save.sh`
+Then locate the save file:
+```bash
+ls -l ~/.local/share/tmux/resurrect/last 2>/dev/null || ls -l ~/.tmux/resurrect/last
+```
+Expected: a `last` symlink pointing to a timestamped `tmux_resurrect_*.txt` file. Note which directory it's in (used in Task 4).
+
+- [ ] **Step 3: Simulate the reboot**
+
+Run: `tmux -L "$S" kill-server`
+Expected: server gone (`tmux -L "$S" list-windows` errors with "no server running").
+
+- [ ] **Step 4: Start a fresh server and restore**
+
+Run:
+```bash
+tmux -L "$S" new-session -d
+tmux -L "$S" source-file ~/dotfiles/tmux/tmux.conf
+tmux -L "$S" run-shell ~/.tmux/plugins/tmux-resurrect/scripts/restore.sh
+sleep 2
+tmux -L "$S" list-windows -a -F '#{window_index} #{pane_current_path}'
+```
+Expected: the three windows with paths `/tmp`, `/usr/local`, and home are restored.
+
+- [ ] **Step 5: Tear down**
+
+Run: `tmux -L "$S" kill-server 2>/dev/null`
+Expected: clean exit. If Steps 1–4 showed the windows/paths returning, baseline persistence works.
+
+---
+
+### Task 4: Tune and commit the Claude-restore rule (single owner)
+
+Determine, empirically, the substring that resurrect captures for a Claude Code pane, set ONE inline `@resurrect-processes` rule using it, and lock it in with a test + a `tmux.conf` comment naming the chosen mechanism (honors the spec's Design note: exactly one owner).
+
+**Files:**
+- Modify: `tmux/tmux.conf` (add the `@resurrect-processes` line inside the persistence block from Task 1)
+- Modify: `tests/test-tmux-persistence.bats` (add a third assertion)
+
+- [ ] **Step 1: Capture how a real Claude pane is saved**
+
+In a tmux pane, start Claude Code (`claude`) in some project dir. In another shell, save and inspect:
+```bash
+RESDIR=~/.local/share/tmux/resurrect; [ -d "$RESDIR" ] || RESDIR=~/.tmux/resurrect
+tmux run-shell ~/.tmux/plugins/tmux-resurrect/scripts/save.sh
+grep -n -i 'claude\|node\|cli' "$RESDIR/last"
+```
+Expected: one or more `pane` lines containing the Claude pane's saved command line. Identify a substring that is present for the Claude pane and NOT present for plain shell panes (likely `claude` from the binary/script path; if absent, fall back to `cli.js` or the resolved node script path).
+
+- [ ] **Step 2: Decide the match string**
+
+- If the saved Claude pane line contains `claude` → match string is `claude`.
+- If it does not, but contains a unique identifier (e.g. `cli.js` under a claude path) → use that exact substring.
+- If the Claude pane is indistinguishable from other `node` panes (no unique token) → STOP and record a limitation: keep only the Task-1 options, do NOT add a `node`-wide rule (it would relaunch every node pane as claude). Note this in the commit and skip Steps 3–6; baseline persistence (Task 3) still ships. This is the spec's "worst case: manual `claude --continue`" outcome.
+
+Set `MATCH` to the chosen substring for the next steps (e.g. `MATCH=claude`).
+
+- [ ] **Step 3: Write the failing assertion**
+
+Add this test to `tests/test-tmux-persistence.bats` (after the existing tests):
+
+```bash
+@test "resurrect relaunches claude panes with --continue" {
+    run tmux -L "$SOCKET" show-options -gv @resurrect-processes
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"claude --continue"* ]]
+}
+```
+
+- [ ] **Step 4: Run it to verify it fails**
+
+Run: `bats tests/test-tmux-persistence.bats`
+Expected: the new test FAILS (`@resurrect-processes` unset); the first two still pass.
+
+- [ ] **Step 5: Add the single inline rule + naming comment**
+
+In `tmux/tmux.conf`, inside the persistence block, append (replace `claude` with the `MATCH` substring from Step 2 if different):
+
+```tmux
+# claude-restore lives HERE — single owner is this inline @resurrect-processes rule.
+# '~claude' loosely matches the saved command line; '->' gives the relaunch command.
+set -g @resurrect-processes '"~claude->claude --continue"'
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bats tests/test-tmux-persistence.bats`
+Expected: all three tests PASS.
+
+- [ ] **Step 7: Empirically confirm the rule relaunches claude (real save/restore)**
+
+Run, with a Claude pane open:
+```bash
+S=persist-claude
+# (do this in your interactive tmux; resurrect operates on the current server)
+tmux run-shell ~/.tmux/plugins/tmux-resurrect/scripts/save.sh
+tmux kill-server   # WARNING: kills your tmux; run only when ready
+# then in a new terminal:
+tmux new-session -d; tmux source-file ~/dotfiles/tmux/tmux.conf
+tmux run-shell ~/.tmux/plugins/tmux-resurrect/scripts/restore.sh; sleep 3
+tmux list-panes -s -F '#{window_index} #{pane_current_command} #{pane_current_path}'
+```
+Expected: the pane that was running Claude shows `claude` (or `node`/version) running again in its original directory — i.e., `claude --continue` was launched. If it comes back as a bare shell, the match string was wrong → return to Step 2.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tmux/tmux.conf tests/test-tmux-persistence.bats
+git commit -m "feat(tmux): relaunch claude panes with --continue on restore"
+```
+
+---
+
+### Task 5: Final end-to-end verification on the real machine
+
+The genuine test of "survive a reboot." This is manual — it needs your actual session and a real `kill-server` (or reboot). Document the result in the PR.
+
+**Files:** none.
+
+- [ ] **Step 1: Enable continuum auto-save in your live session**
+
+Reload your real config: `tmux source-file ~/.tmux.conf`. continuum auto-saves every 15 min once loaded. To not wait, force a save now: `prefix + Ctrl-s` (resurrect manual save).
+
+- [ ] **Step 2: Confirm a save file exists and is recent**
+
+Run: `ls -lt ~/.local/share/tmux/resurrect/ 2>/dev/null || ls -lt ~/.tmux/resurrect/ | head`
+Expected: a `tmux_resurrect_*.txt` from the last minute.
+
+- [ ] **Step 3: Simulate the reboot**
+
+Run: `tmux kill-server` (closes all sessions — make sure work is saved).
+Expected: back at the bare shell prompt, no tmux running.
+
+- [ ] **Step 4: Relaunch tmux and confirm auto-restore**
+
+Run: `tmux`
+Expected: because `@continuum-restore 'on'`, your windows/panes/layout/cwds reappear automatically; scrollback is visible; Claude panes have relaunched with `claude --continue` and show the resumed conversation.
+
+- [ ] **Step 5: Record the outcome**
+
+Note in the PR description what restored correctly (layout, cwd, scrollback, claude resume) and any gaps. Per the spec, the feature is "done" only once a session is observed coming back after this cycle.
+
+---
+
+## Notes for the implementer
+
+- **resurrect save dir** differs by version: newer resurrect uses `~/.local/share/tmux/resurrect`, older uses `~/.tmux/resurrect`. Steps that touch the save file detect both.
+- **Do not** add a `@resurrect-hook-post-restore-all` script. The spec's Design note mandates a single owner for claude-restore; the inline rule is it. The hook is only a documented contingency if Step 2 of Task 4 proves no unique match substring exists — and in that case the chosen outcome is "manual `claude --continue`", not a second mechanism.
+- **`prefix` is `Ctrl-b`**, `mode-keys` is `vi` (unchanged by this work).
+- continuum's 15-min auto-save default is intentionally left as-is (spec YAGNI guard).

--- a/docs/superpowers/plans/2026-06-09-tmux-claude-resume.md
+++ b/docs/superpowers/plans/2026-06-09-tmux-claude-resume.md
@@ -1,0 +1,653 @@
+# Bulletproof Per-Pane Claude Resume — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a reboot, each restored tmux pane that was running Claude Code resumes its own exact conversation by session ID (`claude --resume <id>`), eliminating the same-cwd collision.
+
+**Architecture:** A Claude Code `SessionStart` hook records `{tmux pane → session_id, cwd}` to a registry (using `$CLAUDE_CODE_SESSION_ID` + `$TMUX_PANE`). A tmux-resurrect `@resurrect-hook-post-save-all` script rewrites the just-saved file so each claude pane's restore command becomes `claude <flags> --resume <id>` (or `-r` if the id is unavailable). resurrect's normal restore then replays it. A shared `registry.sh` owns the registry schema. Scripts live in `tmux-claude-resume/`, deploy to `~/.config/tmux-claude-resume/` via `dotfiles.yaml`.
+
+**Tech Stack:** bash, tmux 3.3a, tmux-resurrect/continuum, bats, Claude Code hooks, jq (for settings.json merge).
+
+**Spec:** `docs/superpowers/specs/2026-06-09-tmux-claude-resume-design.md` (blessed). Builds on shipped Tasks 1–3 of the persistence plan (continuum-restore + pane-contents capture already in `tmux/tmux.conf`).
+
+**Branch note:** commits land on `ccc-config-1` (current feature branch) unless decided otherwise at execution start. Steps are branch-agnostic.
+
+---
+
+## File Structure
+
+- **Create:** `tmux-claude-resume/registry.sh` — single-owner registry schema (dir, key sanitization, record/lookup/prune). Sourced by both hooks.
+- **Create:** `tmux-claude-resume/record-tmux-session.sh` — Claude `SessionStart` hook; records pane→session.
+- **Create:** `tmux-claude-resume/resurrect-inject-claude-resume.sh` — resurrect post-save hook; rewrites claude restore commands.
+- **Create:** `tmux-claude-resume/install-hook.sh` — idempotent installer; merges the SessionStart hook into `~/.claude/settings.json`.
+- **Create:** `tests/test-tmux-claude-registry.bats`, `tests/test-tmux-claude-capture.bats`, `tests/test-tmux-claude-inject.bats`, `tests/test-tmux-claude-install.bats`.
+- **Modify:** `tmux/tmux.conf` (persistence block) — add `@resurrect-processes` + `@resurrect-hook-post-save-all`.
+- **Modify:** `dotfiles.yaml` — add the `~/.config/tmux-claude-resume/` link entry.
+
+**Dependency order:** Task 1 (spikes) gates Tasks 4–6. Tasks 2–3 (registry + capture hook) are independent of the spike and may proceed regardless. Do **not** build Task 4 (injection) until Task 1 confirms assumption #1.
+
+---
+
+### Task 1: Spikes — confirm the two load-bearing assumptions
+
+No production code. Two throwaway experiments that gate the rest. If either fails, STOP and escalate (the fallback architecture B2 changes Tasks 4–5 wholesale).
+
+- [ ] **Step 1: Spike B — does `@resurrect-hook-post-save-all` fire with a resolvable save file?**
+
+Run:
+```bash
+S=spike-b; D=/tmp/spike-b-$$; mkdir -p "$D"
+tmux -L "$S" kill-server 2>/dev/null
+tmux -L "$S" -f /dev/null new-session -d
+tmux -L "$S" set -g @resurrect-dir "$D"
+tmux -L "$S" set -g @resurrect-hook-post-save-all "echo fired > $D/HOOK_FIRED"
+tmux -L "$S" run-shell ~/.tmux/plugins/tmux-resurrect/scripts/save.sh
+sleep 1
+ls -l "$D/HOOK_FIRED" "$D/last" 2>&1
+tmux -L "$S" kill-server 2>/dev/null; rm -rf "$D"
+```
+Expected: both `HOOK_FIRED` and the `last` symlink exist. → assumption #2 holds.
+
+- [ ] **Step 2: Spike A — does resurrect replay the (rewritten) trailing command field for `~`-matched processes?**
+
+Run:
+```bash
+S=spike-a; D=/tmp/spike-a-$$; mkdir -p "$D"; M="$D/REPLAYED"
+tmux -L "$S" kill-server 2>/dev/null
+tmux -L "$S" -f /dev/null new-session -d -c /tmp
+tmux -L "$S" set -g @resurrect-dir "$D"
+tmux -L "$S" set -g @resurrect-processes '~sleep'
+# run a long sleep so it's captured as a restorable process
+tmux -L "$S" send-keys 'sleep 600' Enter; sleep 1
+tmux -L "$S" run-shell ~/.tmux/plugins/tmux-resurrect/scripts/save.sh; sleep 1
+echo "--- saved pane line(s) ---"; grep '^pane' "$D/last"
+# Rewrite the trailing command field: replace 'sleep 600' with a command that proves replay
+sed -i '' "s#:sleep 600#:touch $M && sleep 600#" "$D/last" 2>/dev/null || sed -i "s#:sleep 600#:touch $M \&\& sleep 600#" "$D/last"
+tmux -L "$S" kill-server
+tmux -L "$S" -f /dev/null new-session -d
+tmux -L "$S" set -g @resurrect-dir "$D"
+tmux -L "$S" set -g @resurrect-processes '~sleep'
+tmux -L "$S" run-shell ~/.tmux/plugins/tmux-resurrect/scripts/restore.sh; sleep 3
+ls -l "$M" 2>&1 && echo "REPLAY CONFIRMED (rewritten command field ran)" || echo "REPLAY FAILED"
+tmux -L "$S" kill-server 2>/dev/null; rm -rf "$D"
+```
+Expected: `$M` exists → resurrect ran the **rewritten** trailing command field. This confirms assumption #1 AND identifies that the trailing (last, colon-prefixed) field is the one replayed — the field Task 4 rewrites.
+
+- [ ] **Step 3: Record the outcome**
+
+If both spikes pass, note in the PR/commit message "spikes A+B confirmed" and proceed. If either fails, STOP: the post-save-rewrite architecture (B1) is not viable as specced — escalate to revisit B2 (post-restore keystroke injection) per the spec. Do not start Task 4.
+
+---
+
+### Task 2: Registry helper + tests
+
+**Files:**
+- Create: `tmux-claude-resume/registry.sh`
+- Test: `tests/test-tmux-claude-registry.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test-tmux-claude-registry.bats`:
+```bash
+#!/usr/bin/env bats
+# Test: tmux-claude-resume registry helper
+
+setup() {
+    export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export TMUX_CLAUDE_RESUME_DIR="$(mktemp -d)"
+    source "$DOTFILES_DIR/tmux-claude-resume/registry.sh"
+}
+teardown() { rm -rf "$TMUX_CLAUDE_RESUME_DIR"; }
+
+@test "record then lookup returns the session id" {
+    tcr_record "%5" "abc-123" "/tmp/proj"
+    run tcr_session_id "%5"
+    [ "$status" -eq 0 ]
+    [ "$output" = "abc-123" ]
+}
+
+@test "lookup of unknown pane prints nothing, exits 0" {
+    run tcr_session_id "%9"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "record overwrites the prior mapping for a pane" {
+    tcr_record "%5" "old-id" "/tmp/a"
+    tcr_record "%5" "new-id" "/tmp/b"
+    run tcr_session_id "%5"
+    [ "$output" = "new-id" ]
+}
+
+@test "prune removes entries whose pane is not in the live set" {
+    tcr_record "%1" "s1" "/tmp/1"
+    tcr_record "%2" "s2" "/tmp/2"
+    tcr_prune "%1"
+    run tcr_session_id "%1"; [ "$output" = "s1" ]
+    run tcr_session_id "%2"; [ -z "$output" ]
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bats tests/test-tmux-claude-registry.bats`
+Expected: FAIL — `registry.sh` does not exist (`source` errors / functions undefined).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tmux-claude-resume/registry.sh`:
+```bash
+#!/usr/bin/env bash
+# Single source of truth for the tmux-claude-resume pane->session registry.
+# Schema: one file per tmux pane under the registry dir, named by a sanitized
+# pane id, containing a single line: "<session_id>\t<cwd>".
+# Override the dir with $TMUX_CLAUDE_RESUME_DIR (used by tests).
+
+tcr_registry_dir() {
+    echo "${TMUX_CLAUDE_RESUME_DIR:-$HOME/.cache/tmux-claude-resume}"
+}
+
+# Map a tmux pane id (e.g. "%5") to a safe filename (e.g. "pane_5").
+tcr_pane_key() {
+    printf 'pane_%s' "${1//[^A-Za-z0-9]/_}"
+}
+
+# Record (overwrite) the mapping for a pane.
+tcr_record() {
+    local pane="$1" session_id="$2" cwd="$3" dir
+    dir="$(tcr_registry_dir)"
+    mkdir -p "$dir"
+    printf '%s\t%s\n' "$session_id" "$cwd" > "$dir/$(tcr_pane_key "$pane")"
+}
+
+# Print the session id recorded for a pane (nothing if absent). Always exits 0.
+tcr_session_id() {
+    local file
+    file="$(tcr_registry_dir)/$(tcr_pane_key "$1")"
+    [ -f "$file" ] || return 0
+    cut -f1 "$file"
+}
+
+# Remove registry files whose pane is not in the given live-pane list.
+# Usage: tcr_prune "%1" "%2" ...
+tcr_prune() {
+    local dir f base; dir="$(tcr_registry_dir)"
+    [ -d "$dir" ] || return 0
+    declare -A keep=()
+    local p; for p in "$@"; do keep["$(tcr_pane_key "$p")"]=1; done
+    for f in "$dir"/pane_*; do
+        [ -e "$f" ] || continue
+        base="$(basename "$f")"
+        [ -n "${keep[$base]:-}" ] || rm -f "$f"
+    done
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bats tests/test-tmux-claude-registry.bats`
+Expected: 4/4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tmux-claude-resume/registry.sh tests/test-tmux-claude-registry.bats
+git commit -m "feat(tmux-claude-resume): add single-owner pane->session registry helper"
+```
+
+---
+
+### Task 3: Capture hook + tests
+
+**Files:**
+- Create: `tmux-claude-resume/record-tmux-session.sh`
+- Test: `tests/test-tmux-claude-capture.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test-tmux-claude-capture.bats`:
+```bash
+#!/usr/bin/env bats
+# Test: tmux-claude-resume SessionStart capture hook
+
+setup() {
+    export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export TMUX_CLAUDE_RESUME_DIR="$(mktemp -d)"
+    export HOOK="$DOTFILES_DIR/tmux-claude-resume/record-tmux-session.sh"
+}
+teardown() { rm -rf "$TMUX_CLAUDE_RESUME_DIR"; }
+
+@test "records the mapping when in tmux with a session id" {
+    run env TMUX="/tmp/x,1,0" TMUX_PANE="%3" CLAUDE_CODE_SESSION_ID="sess-1" \
+        PWD="/tmp/proj" TMUX_CLAUDE_RESUME_DIR="$TMUX_CLAUDE_RESUME_DIR" bash "$HOOK"
+    [ "$status" -eq 0 ]
+    source "$DOTFILES_DIR/tmux-claude-resume/registry.sh"
+    run tcr_session_id "%3"
+    [ "$output" = "sess-1" ]
+}
+
+@test "no-op when not in tmux (TMUX unset)" {
+    run env -u TMUX TMUX_PANE="%3" CLAUDE_CODE_SESSION_ID="sess-1" \
+        TMUX_CLAUDE_RESUME_DIR="$TMUX_CLAUDE_RESUME_DIR" bash "$HOOK"
+    [ "$status" -eq 0 ]
+    [ -z "$(ls -A "$TMUX_CLAUDE_RESUME_DIR" 2>/dev/null)" ]
+}
+
+@test "no-op when CLAUDE_CODE_SESSION_ID is missing" {
+    run env TMUX="/tmp/x,1,0" TMUX_PANE="%3" -u CLAUDE_CODE_SESSION_ID \
+        TMUX_CLAUDE_RESUME_DIR="$TMUX_CLAUDE_RESUME_DIR" bash "$HOOK"
+    [ "$status" -eq 0 ]
+    [ -z "$(ls -A "$TMUX_CLAUDE_RESUME_DIR" 2>/dev/null)" ]
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bats tests/test-tmux-claude-capture.bats`
+Expected: FAIL — hook script does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tmux-claude-resume/record-tmux-session.sh`:
+```bash
+#!/usr/bin/env bash
+# Claude Code SessionStart hook. Records this pane's session id so tmux-resurrect
+# can later relaunch the pane with `claude --resume <id>`. No-op outside tmux.
+set -euo pipefail
+
+# Need all three identifiers; otherwise we cannot (or should not) record.
+[ -n "${TMUX:-}" ] || exit 0
+[ -n "${TMUX_PANE:-}" ] || exit 0
+[ -n "${CLAUDE_CODE_SESSION_ID:-}" ] || exit 0
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=registry.sh
+source "$here/registry.sh"
+
+tcr_record "$TMUX_PANE" "$CLAUDE_CODE_SESSION_ID" "$PWD"
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bats tests/test-tmux-claude-capture.bats`
+Expected: 3/3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tmux-claude-resume/record-tmux-session.sh tests/test-tmux-claude-capture.bats
+git commit -m "feat(tmux-claude-resume): add SessionStart hook to record pane->session"
+```
+
+---
+
+### Task 4: Injection hook + tests  (GATED on Task 1 spike A)
+
+**Files:**
+- Create: `tmux-claude-resume/resurrect-inject-claude-resume.sh`
+- Test: `tests/test-tmux-claude-inject.bats`
+
+The test stubs `tmux` (a fake on `PATH`) and `~/.claude/projects` so it runs without a live server.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test-tmux-claude-inject.bats`:
+```bash
+#!/usr/bin/env bats
+# Test: tmux-claude-resume resurrect post-save injection
+
+setup() {
+    export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export WORK="$(mktemp -d)"
+    export TMUX_CLAUDE_RESUME_DIR="$WORK/registry"
+    export RESDIR="$WORK/resurrect"
+    export FAKE_HOME="$WORK/home"
+    mkdir -p "$RESDIR" "$FAKE_HOME/.claude/projects/-tmp-proj"
+    export INJECT="$DOTFILES_DIR/tmux-claude-resume/resurrect-inject-claude-resume.sh"
+
+    # Stub tmux: answer the two queries the script makes.
+    mkdir -p "$WORK/bin"
+    cat > "$WORK/bin/tmux" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  "show-options -gv @resurrect-dir") echo "$RESDIR" ;;
+  "list-panes -a -F"*) printf 'main\t1\t0\t%%1\nmain\t1\t1\t%%2\n' ;;
+  *) exit 0 ;;
+esac
+EOF
+    chmod +x "$WORK/bin/tmux"
+    export PATH="$WORK/bin:$PATH"
+
+    # Registry: pane %1 -> known session WITH a jsonl; pane %2 -> session WITHOUT jsonl.
+    source "$DOTFILES_DIR/tmux-claude-resume/registry.sh"
+    tcr_record "%1" "live-sess" "/tmp/proj"
+    tcr_record "%2" "dead-sess" "/tmp/proj"
+    : > "$FAKE_HOME/.claude/projects/-tmp-proj/live-sess.jsonl"   # exists
+    # dead-sess.jsonl intentionally absent
+
+    # Save file: pane %1 (session exists), pane %2 (session gone), and a non-claude pane.
+    printf 'pane\tmain\t1\t0\t:\t0\t title\t:/tmp/proj\t1\t2.1.168\t:claude --dangerously-skip-permissions -r\n'  > "$RESDIR/last"
+    printf 'pane\tmain\t1\t0\t:\t1\t title\t:/tmp/proj\t0\t2.1.168\t:claude --dangerously-skip-permissions -r\n' >> "$RESDIR/last"
+    printf 'pane\tmain\t1\t0\t:\t2\t title\t:/tmp/proj\t0\tvim\t:vim\n'                                          >> "$RESDIR/last"
+}
+teardown() { rm -rf "$WORK"; }
+
+@test "pane with a live session is rewritten to --resume <id>, flags preserved" {
+    HOME="$FAKE_HOME" run bash "$INJECT"
+    [ "$status" -eq 0 ]
+    run grep -c ':claude --dangerously-skip-permissions --resume live-sess$' "$RESDIR/last"
+    [ "$output" = "1" ]
+}
+
+@test "pane whose session is gone falls back to -r, flags preserved" {
+    HOME="$FAKE_HOME" run bash "$INJECT"
+    run grep -c ':claude --dangerously-skip-permissions -r$' "$RESDIR/last"
+    [ "$output" = "1" ]
+}
+
+@test "non-claude pane line is left untouched" {
+    HOME="$FAKE_HOME" run bash "$INJECT"
+    run grep -c ':vim$' "$RESDIR/last"
+    [ "$output" = "1" ]
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bats tests/test-tmux-claude-inject.bats`
+Expected: FAIL — injection script does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tmux-claude-resume/resurrect-inject-claude-resume.sh`:
+```bash
+#!/usr/bin/env bash
+# tmux-resurrect @resurrect-hook-post-save-all hook.
+# Rewrites each claude pane's restore command in the just-saved file to
+# `claude <preserved-flags> --resume <id>` (or `... -r` if the id is unavailable),
+# so a restore reattaches each pane to its own Claude Code session.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=registry.sh
+source "$here/registry.sh"
+
+res_dir="$(tmux show-options -gv @resurrect-dir 2>/dev/null || true)"
+res_dir="${res_dir:-$HOME/.tmux/resurrect}"
+save="$res_dir/last"
+[ -f "$save" ] || exit 0
+real="$(readlink "$save" 2>/dev/null || true)"; real="${real:-$save}"
+case "$real" in /*) ;; *) real="$res_dir/$real" ;; esac
+
+# Live (session|window|pane_index) -> pane_id map.
+declare -A paneid=()
+while IFS=$'\t' read -r s w p id; do
+    paneid["$s|$w|$p"]="$id"
+done < <(tmux list-panes -a -F '#{session_name}	#{window_index}	#{pane_index}	#{pane_id}')
+
+projects="$HOME/.claude/projects"
+
+# Given the original full command + pane_id, produce the restore command.
+rewrite_cmd() {
+    local cmd="$1" pane_id="$2" flags sid
+    # Strip any existing resume/continue flags; keep the rest (e.g. --dangerously-skip-permissions).
+    flags="$(printf '%s' "$cmd" \
+        | sed -E 's/(^| )(-r|--resume([= ][^ ]+)?|-c|--continue)( |$)/ /g; s/  +/ /g; s/ +$//')"
+    sid="$(tcr_session_id "$pane_id")"
+    if [ -n "$sid" ] && compgen -G "$projects/*/$sid.jsonl" > /dev/null; then
+        printf '%s --resume %s' "$flags" "$sid"
+    else
+        printf '%s -r' "$flags"
+    fi
+}
+
+tmp="$(mktemp)"
+while IFS= read -r line || [ -n "$line" ]; do
+    if [ "${line%%$'\t'*}" = "pane" ] && printf '%s' "$line" | grep -q 'claude'; then
+        IFS=$'\t' read -r -a f <<< "$line"
+        s="${f[1]}"; w="${f[2]}"; pidx="${f[5]}"
+        pane_id="${paneid["$s|$w|$pidx"]:-}"
+        last=$(( ${#f[@]} - 1 ))
+        cmd="${f[$last]#:}"
+        if [ -n "$pane_id" ]; then
+            f[$last]=":$(rewrite_cmd "$cmd" "$pane_id")"
+            line="$(printf '%s\t' "${f[@]}")"; line="${line%$'\t'}"
+        fi
+    fi
+    printf '%s\n' "$line"
+done < "$real" > "$tmp"
+mv "$tmp" "$real"
+
+# Prune registry entries for panes that no longer exist.
+mapfile -t live < <(tmux list-panes -a -F '#{pane_id}')
+tcr_prune "${live[@]}"
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bats tests/test-tmux-claude-inject.bats`
+Expected: 3/3 PASS.
+
+- [ ] **Step 5: Run shellcheck on all three scripts**
+
+Run: `shellcheck tmux-claude-resume/registry.sh tmux-claude-resume/record-tmux-session.sh tmux-claude-resume/resurrect-inject-claude-resume.sh`
+Expected: clean (source directives already annotated).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tmux-claude-resume/resurrect-inject-claude-resume.sh tests/test-tmux-claude-inject.bats
+git commit -m "feat(tmux-claude-resume): rewrite resurrect save file to resume each claude pane by id"
+```
+
+---
+
+### Task 5: Wire tmux.conf + dotfiles.yaml deployment
+
+**Files:**
+- Modify: `tmux/tmux.conf` (persistence block)
+- Modify: `dotfiles.yaml` (links)
+- Test: extend `tests/test-tmux-persistence.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test-tmux-persistence.bats` (after the existing tests):
+```bash
+@test "resurrect treats claude as a restorable process" {
+    run tmux -L "$SOCKET" show-options -gv @resurrect-processes
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"~claude"* ]]
+}
+
+@test "resurrect post-save hook points at the deployed injection script" {
+    run tmux -L "$SOCKET" show-options -gv @resurrect-hook-post-save-all
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tmux-claude-resume/resurrect-inject-claude-resume.sh"* ]]
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bats tests/test-tmux-persistence.bats`
+Expected: the two new tests FAIL (options unset); the earlier ones still pass.
+
+- [ ] **Step 3: Add the tmux.conf options**
+
+In `tmux/tmux.conf`, inside the `# --- session persistence (resurrect + continuum) ---` block (immediately after the `@resurrect-capture-pane-contents` line), add:
+```tmux
+# relaunch each claude pane on restore; the post-save hook rewrites the saved
+# command to `claude --resume <id>` per pane (see tmux-claude-resume/).
+set -g @resurrect-processes '~claude'
+set -g @resurrect-hook-post-save-all 'bash ~/.config/tmux-claude-resume/resurrect-inject-claude-resume.sh'
+```
+
+- [ ] **Step 4: Add the dotfiles.yaml link entry**
+
+In `dotfiles.yaml`, under `links:`, add (matching the existing `~/.config/...` indentation style):
+```yaml
+    ~/.config/tmux-claude-resume/:          tmux-claude-resume/*
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bats tests/test-tmux-persistence.bats`
+Expected: all tests PASS (old + 2 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tmux/tmux.conf dotfiles.yaml tests/test-tmux-persistence.bats
+git commit -m "feat(tmux): wire claude-resume injection hook + deploy scripts via dotfiles.yaml"
+```
+
+---
+
+### Task 6: Idempotent settings.json installer + tests  (GATED on Task 1)
+
+**Files:**
+- Create: `tmux-claude-resume/install-hook.sh`
+- Test: `tests/test-tmux-claude-install.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test-tmux-claude-install.bats`:
+```bash
+#!/usr/bin/env bats
+# Test: tmux-claude-resume settings.json hook installer (idempotent merge)
+
+setup() {
+    export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export FAKE_HOME="$(mktemp -d)"
+    mkdir -p "$FAKE_HOME/.claude"
+    # pre-existing unrelated settings to prove we don't clobber
+    printf '{"model":"opus","hooks":{}}\n' > "$FAKE_HOME/.claude/settings.json"
+    export INSTALL="$DOTFILES_DIR/tmux-claude-resume/install-hook.sh"
+}
+teardown() { rm -rf "$FAKE_HOME"; }
+
+@test "adds the SessionStart hook and preserves unrelated keys" {
+    HOME="$FAKE_HOME" run bash "$INSTALL"
+    [ "$status" -eq 0 ]
+    run jq -r '.model' "$FAKE_HOME/.claude/settings.json"
+    [ "$output" = "opus" ]
+    run jq '[.hooks.SessionStart[].hooks[].command] | map(select(test("record-tmux-session.sh"))) | length' "$FAKE_HOME/.claude/settings.json"
+    [ "$output" = "1" ]
+}
+
+@test "running twice is idempotent (hook present exactly once)" {
+    HOME="$FAKE_HOME" bash "$INSTALL"
+    HOME="$FAKE_HOME" run bash "$INSTALL"
+    [ "$status" -eq 0 ]
+    run jq '[.. | objects | .command? // empty | select(test("record-tmux-session.sh"))] | length' "$FAKE_HOME/.claude/settings.json"
+    [ "$output" = "1" ]
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bats tests/test-tmux-claude-install.bats`
+Expected: FAIL — installer does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `tmux-claude-resume/install-hook.sh`:
+```bash
+#!/usr/bin/env bash
+# Idempotently register the tmux-claude-resume SessionStart hook in the user's
+# GLOBAL ~/.claude/settings.json. Never touches any repo-local .claude/settings.json.
+set -euo pipefail
+
+settings="$HOME/.claude/settings.json"
+cmd="$HOME/.config/tmux-claude-resume/record-tmux-session.sh"
+
+mkdir -p "$(dirname "$settings")"
+[ -f "$settings" ] || echo '{}' > "$settings"
+
+# Already present? Then this is a no-op.
+if jq -e --arg c "$cmd" \
+    '[.. | objects | .command? // empty] | any(. == $c)' "$settings" > /dev/null; then
+    echo "tmux-claude-resume hook already installed"
+    exit 0
+fi
+
+tmp="$(mktemp)"
+jq --arg c "$cmd" '
+    .hooks //= {} |
+    .hooks.SessionStart //= [] |
+    .hooks.SessionStart += [{
+        "matcher": "startup|resume",
+        "hooks": [{ "type": "command", "command": $c }]
+    }]
+' "$settings" > "$tmp"
+mv "$tmp" "$settings"
+echo "tmux-claude-resume hook installed in $settings"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bats tests/test-tmux-claude-install.bats`
+Expected: 2/2 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tmux-claude-resume/install-hook.sh tests/test-tmux-claude-install.bats
+git commit -m "feat(tmux-claude-resume): idempotent ~/.claude/settings.json hook installer"
+```
+
+---
+
+### Task 7: Deploy + manual end-to-end verification (gated, on the live machine)
+
+No repo changes. This is the real proof; it touches the user's live tmux and global settings, so it is run by the user at a checkpoint.
+
+- [ ] **Step 1: Full suite + shellcheck green**
+
+Run: `bats tests/ && shellcheck tmux-claude-resume/*.sh install.sh`
+Expected: new suites pass; pre-existing baseline failures unchanged; shellcheck clean.
+
+- [ ] **Step 2: Deploy the scripts and register the hook**
+
+Run:
+```bash
+./dot.py link                                   # symlinks ~/.config/tmux-claude-resume/ -> repo
+ls -l ~/.config/tmux-claude-resume/             # expect the 4 scripts
+bash ~/.config/tmux-claude-resume/install-hook.sh
+jq '.hooks.SessionStart' ~/.claude/settings.json
+```
+Expected: scripts present; SessionStart hook registered once.
+
+- [ ] **Step 3: Prime the registry**
+
+Reload tmux config (`tmux source-file ~/.tmux.conf`). In two panes sharing one cwd, start `claude` (your normal alias). Confirm the capture hook fired:
+```bash
+ls -l ~/.cache/tmux-claude-resume/    # one file per claude pane
+cat ~/.cache/tmux-claude-resume/*     # each: <session_id><TAB><cwd>
+```
+Expected: distinct session ids for the two same-cwd panes.
+
+- [ ] **Step 4: Save → simulate reboot → restore**
+
+Run (when ready — `kill-server` ends your sessions):
+```bash
+tmux run-shell ~/.tmux/plugins/tmux-resurrect/scripts/save.sh
+grep claude "$(tmux show-options -gv @resurrect-dir 2>/dev/null || echo ~/.tmux/resurrect)/last"
+# expect each claude pane line ends with `--resume <its own id>`
+tmux kill-server
+tmux            # continuum auto-restores
+```
+Expected after restart: each pane resumed its **own** conversation; the two same-cwd panes show different conversations (collision gone).
+
+- [ ] **Step 5: Record the outcome**
+
+Note in the PR what restored correctly (per-pane resume, same-cwd disambiguation, `-r` fallback for any pane whose session was gone). Per the spec, "done" requires observing distinct same-cwd sessions resume after this cycle.
+
+---
+
+## Notes for the implementer
+
+- **resurrect save dir** varies: `~/.local/share/tmux/resurrect` (newer) or `~/.tmux/resurrect`. The injection script reads `@resurrect-dir` (default `~/.tmux/resurrect`); confirm which your install uses during Task 1.
+- **The trailing command field** is the one resurrect replays — Task 1 spike A confirms this and that rewriting it changes what launches. The injection script rewrites the last tab field of each claude `pane` line.
+- **`jq` is required** by the installer; it is already on this machine (`/opt/homebrew/bin/jq`, and listed in `dotfiles.yaml` brew installs).
+- **Do not build Tasks 4 or 6 before Task 1 passes.** If a spike fails, stop and revisit architecture B2 (post-restore keystroke injection) per the spec — that invalidates Tasks 4–5.
+- `prefix` is `Ctrl-b`; continuum auto-save interval is the 15-min default (unchanged).

--- a/docs/superpowers/plans/2026-06-09-tmux-claude-resume.md
+++ b/docs/superpowers/plans/2026-06-09-tmux-claude-resume.md
@@ -1,3 +1,17 @@
+---
+validated:
+  sha: e397914ac165f85d1319ccc198623711834a751e
+  date: 2026-06-09T19:28:59Z
+  reviewers: [fact-check, solid-hygiene]
+  findings:
+    critical: 0
+    important: 0
+    medium: 2
+    low: 4
+    nitpick: 0
+  net_negative_remaining: 0
+---
+
 # Bulletproof Per-Pane Claude Resume — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
@@ -141,7 +155,9 @@ Create `tmux-claude-resume/registry.sh`:
 # Single source of truth for the tmux-claude-resume pane->session registry.
 # Schema: one file per tmux pane under the registry dir, named by a sanitized
 # pane id, containing a single line: "<session_id>\t<cwd>".
-# Override the dir with $TMUX_CLAUDE_RESUME_DIR (used by tests).
+# The cwd field is diagnostic/reserved — no consumer reads it today; only field 1
+# (session_id) is load-bearing. Override the dir with $TMUX_CLAUDE_RESUME_DIR (tests).
+# Prune contract: tcr_prune requires a NON-EMPTY live-pane set (see resurrect-inject).
 
 tcr_registry_dir() {
     echo "${TMUX_CLAUDE_RESUME_DIR:-$HOME/.cache/tmux-claude-resume}"
@@ -311,7 +327,8 @@ setup() {
 #!/usr/bin/env bash
 case "\$*" in
   "show-options -gv @resurrect-dir") echo "$RESDIR" ;;
-  "list-panes -a -F"*) printf 'main\t1\t0\t%%1\nmain\t1\t1\t%%2\n' ;;
+  "list-panes -a -F #{pane_id}") printf '%%1\n%%2\n' ;;          # bare pane-id query (prune)
+  "list-panes -a -F"*) printf 'main\t1\t0\t%%1\nmain\t1\t1\t%%2\n' ;;  # 4-field join query
   *) exit 0 ;;
 esac
 EOF
@@ -373,6 +390,7 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$here/registry.sh"
 
 res_dir="$(tmux show-options -gv @resurrect-dir 2>/dev/null || true)"
+# Fallback mirrors tmux-resurrect's own default; Task 1 confirms the live dir.
 res_dir="${res_dir:-$HOME/.tmux/resurrect}"
 save="$res_dir/last"
 [ -f "$save" ] || exit 0
@@ -401,26 +419,32 @@ rewrite_cmd() {
     fi
 }
 
+# --- Phase 1: rewrite each claude pane's restore command in the save file ---
 tmp="$(mktemp)"
 while IFS= read -r line || [ -n "$line" ]; do
-    if [ "${line%%$'\t'*}" = "pane" ] && printf '%s' "$line" | grep -q 'claude'; then
+    if [ "${line%%$'\t'*}" = "pane" ]; then
         IFS=$'\t' read -r -a f <<< "$line"
-        s="${f[1]}"; w="${f[2]}"; pidx="${f[5]}"
-        pane_id="${paneid["$s|$w|$pidx"]:-}"
         last=$(( ${#f[@]} - 1 ))
-        cmd="${f[$last]#:}"
-        if [ -n "$pane_id" ]; then
-            f[$last]=":$(rewrite_cmd "$cmd" "$pane_id")"
-            line="$(printf '%s\t' "${f[@]}")"; line="${line%$'\t'}"
+        cmd="${f[$last]#:}"   # trailing field = the full command resurrect replays
+        # Anchor on the COMMAND field, not the whole line: a pane whose cwd merely
+        # contains "claude" must not be misclassified as a claude pane.
+        if [[ "$cmd" == "claude" || "$cmd" == claude\ * ]]; then
+            s="${f[1]}"; w="${f[2]}"; pidx="${f[5]}"
+            pane_id="${paneid["$s|$w|$pidx"]:-}"
+            if [ -n "$pane_id" ]; then
+                f[$last]=":$(rewrite_cmd "$cmd" "$pane_id")"
+                line="$(printf '%s\t' "${f[@]}")"; line="${line%$'\t'}"
+            fi
         fi
     fi
     printf '%s\n' "$line"
 done < "$real" > "$tmp"
 mv "$tmp" "$real"
 
-# Prune registry entries for panes that no longer exist.
+# --- Phase 2: prune registry entries for panes that no longer exist ---
+# Guard: never call tcr_prune with zero live panes (that would wipe the registry).
 mapfile -t live < <(tmux list-panes -a -F '#{pane_id}')
-tcr_prune "${live[@]}"
+[ "${#live[@]}" -gt 0 ] && tcr_prune "${live[@]}"
 ```
 
 - [ ] **Step 4: Run the test to verify it passes**
@@ -603,7 +627,7 @@ No repo changes. This is the real proof; it touches the user's live tmux and glo
 
 - [ ] **Step 1: Full suite + shellcheck green**
 
-Run: `bats tests/ && shellcheck tmux-claude-resume/*.sh install.sh`
+Run: `bats tests/ && shellcheck tmux-claude-resume/*.sh`
 Expected: new suites pass; pre-existing baseline failures unchanged; shellcheck clean.
 
 - [ ] **Step 2: Deploy the scripts and register the hook**
@@ -651,3 +675,13 @@ Note in the PR what restored correctly (per-pane resume, same-cwd disambiguation
 - **`jq` is required** by the installer; it is already on this machine (`/opt/homebrew/bin/jq`, and listed in `dotfiles.yaml` brew installs).
 - **Do not build Tasks 4 or 6 before Task 1 passes.** If a spike fails, stop and revisit architecture B2 (post-restore keystroke injection) per the spec — that invalidates Tasks 4–5.
 - `prefix` is `Ctrl-b`; continuum auto-save interval is the 15-min default (unchanged).
+
+> **Design note (2026-06-09, validate):** Plan tightened after review — the injection
+> script now (a) anchors the claude match to the **command field** (not the whole line, so a
+> cwd containing "claude" isn't misclassified), (b) is split into clearly-commented Phase 1
+> (rewrite) / Phase 2 (prune) sections, and (c) guards `tcr_prune` against an empty live-pane
+> set (which would otherwise wipe the registry). `registry.sh` documents that `cwd` is
+> diagnostic/reserved and that prune requires a non-empty set. Task 4's `tmux` test stub now
+> answers the bare `#{pane_id}` prune query distinctly from the 4-field join query. All
+> reviewer-confirmed facts (resurrect field order, trailing-field replay, `~` match,
+> `CLAUDE_CODE_SESSION_ID`) verified true.

--- a/docs/superpowers/plans/2026-06-09-tmux-claude-resume.md
+++ b/docs/superpowers/plans/2026-06-09-tmux-claude-resume.md
@@ -444,7 +444,11 @@ mv "$tmp" "$real"
 # --- Phase 2: prune registry entries for panes that no longer exist ---
 # Guard: never call tcr_prune with zero live panes (that would wipe the registry).
 mapfile -t live < <(tmux list-panes -a -F '#{pane_id}')
-[ "${#live[@]}" -gt 0 ] && tcr_prune "${live[@]}"
+# Full `if` (not `&&`): as the script's last statement, a false `&&` would exit 1
+# under `set -e` in exactly the no-live-panes case the guard handles.
+if [ "${#live[@]}" -gt 0 ]; then
+    tcr_prune "${live[@]}"
+fi
 ```
 
 - [ ] **Step 4: Run the test to verify it passes**

--- a/docs/superpowers/specs/2026-06-06-tmux-tpm-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-06-06-tmux-tpm-bootstrap-design.md
@@ -1,0 +1,90 @@
+# Design: Bootstrap TPM and harden tmux plugin sourcing
+
+**Date:** 2026-06-06
+**Status:** Approved
+**Branch:** ccc-config-1
+
+## Problem
+
+On tmux startup the following error appears:
+
+```
+/Users/stavxyz/dotfiles/tmux/tmux.conf:61: /Users/stavxyz/.tmux/plugins/tmux-colors-solarized/tmuxcolors-dark.
+ No such file or directory
+```
+
+Root cause: the dotfiles bootstrap never installs TPM (tmux plugin manager).
+`tmux/tmux.conf` declares 8 plugins via TPM (including `seebi/tmux-colors-solarized`)
+and runs `'$HOME/.tmux/plugins/tpm/tpm'`, but `~/.tmux/` does not exist. None of the
+plugins load. Line 61 then unconditionally `source`s a solarized colorscheme file from a
+plugin that was never downloaded, producing the error. `install.sh` and `dotfiles.yaml`
+contain no TPM setup, so this breaks on every fresh machine.
+
+## Scope
+
+Fix the root cause (bootstrap) and the visible symptom (unguarded source). Two files:
+
+1. `install.sh` — bootstrap TPM.
+2. `tmux/tmux.conf` — guard the solarized `source` lines.
+
+### Out of scope (YAGNI)
+
+- Auto-running `tpm/bin/install_plugins` (plugins install via `prefix + I`, TPM's standard UX).
+- Reordering `install.sh` vs `./dot.py link`.
+- Touching the other 7 declared plugins or unrelated tmux config.
+
+## Design
+
+### 1. `tmux/tmux.conf` — guard the source lines
+
+tmux is 3.3a; `source-file -q` (suppress error if file is missing, tmux 3.0+) is available.
+
+Change lines 61–62 from `source ...` to `source -q ...`:
+
+```
+if '[ "$ITERM_PROFILE" = "dark" ]'  'source -q $HOME/.tmux/plugins/tmux-colors-solarized/tmuxcolors-dark.conf'  ''
+if '[ "$ITERM_PROFILE" = "light" ]' 'source -q $HOME/.tmux/plugins/tmux-colors-solarized/tmuxcolors-light.conf' ''
+```
+
+Result: no error whether or not the solarized plugin is installed. Once installed
+(`prefix + I`), the colorscheme still applies normally.
+
+### 2. `install.sh` — bootstrap TPM
+
+Add an idempotent block mirroring the existing vim-plug block, placed after the
+Vim Plugin Manager section:
+
+```bash
+# ============================================================================
+# TMUX Plugin Manager (TPM)
+# ============================================================================
+
+if [[ -d ~/.tmux/plugins/tpm ]]; then
+    echo "✓ TPM (tmux plugin manager) already installed"
+else
+    echo "Installing TPM (tmux plugin manager)..."
+    git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+fi
+```
+
+Also:
+- Update the header comment block ("Prerequisites installed" + update-method notes) to
+  mention TPM.
+- Update the closing "Next steps" to note that inside tmux, `prefix + I` installs the
+  declared plugins.
+
+### 3. Local fix-up (this machine)
+
+Run the same clone now so the current machine works, then the user presses `prefix + I`
+once and reloads tmux.
+
+## Testing
+
+- `bash -n install.sh` (syntax) and `shellcheck install.sh` (lint — note: root
+  `install.sh` is not in CI's shellcheck path, so run locally).
+- Idempotency: the new block prints the ✓ branch on a second run.
+- Reload tmux (`tmux source-file ~/.tmux.conf`) and confirm the line-61 error is gone.
+
+## Commit / PR
+
+Commit on existing feature branch `ccc-config-1` (not main).

--- a/docs/superpowers/specs/2026-06-07-tmux-session-persistence-design.md
+++ b/docs/superpowers/specs/2026-06-07-tmux-session-persistence-design.md
@@ -1,0 +1,92 @@
+# Design: tmux session persistence across reboot
+
+**Date:** 2026-06-07
+**Status:** Approved
+**Branch:** ccc-config-1 (branch/PR strategy decided at implementation time)
+**Depends on:** TPM bootstrap (PR #31 / `2026-06-06-tmux-tpm-bootstrap-design.md`)
+
+## Goal
+
+After a machine reboot, the first time the user runs `tmux`, their windows, panes,
+layout, and per-pane working directories are restored, and each Claude Code pane
+resumes its conversation via `claude --continue`.
+
+Restore trigger (chosen): **restore when tmux is next launched** — no launchd boot
+agent, nothing auto-starts. continuum auto-saves in the background; `@continuum-restore`
+brings sessions back the moment the tmux server next starts.
+
+## Background
+
+`tmux/tmux.conf` already declares the needed plugins but never configured them:
+
+- `tmux-plugins/tmux-resurrect` (line 49) — save/restore session state.
+- `tmux-plugins/tmux-continuum` (line 50) — periodic auto-save + restore-on-launch.
+
+No `@resurrect-*` or `@continuum-*` options are set anywhere. The plugins are also not
+yet installed (TPM bootstrap landed in PR #31; plugins install via `prefix + I`).
+
+Claude Code supports resume: `-c, --continue` (continue the most recent conversation in
+the current directory) and `-r, --resume [id]`. Because resurrect restores each pane's
+cwd, `claude --continue` in a restored pane resumes that directory's latest conversation.
+
+## Design
+
+### 1. Install plugins (one-time, user's machine)
+
+`prefix + I` inside tmux installs all declared TPM plugins, including resurrect and
+continuum (and sensible/yank/prefix-highlight/solarized — already declared, expected).
+
+### 2. tmux.conf — session persistence block
+
+Add to the plugins section **before** the `run '$HOME/.tmux/plugins/tpm/tpm'` line (56),
+so the plugins read the options at load:
+
+```tmux
+# --- session persistence (resurrect + continuum) ---
+set -g @continuum-restore 'on'                 # auto-restore on tmux server start
+set -g @resurrect-capture-pane-contents 'on'   # snapshot scrollback (read the pre-reboot screen)
+# relaunch Claude Code panes as `claude --continue` (exact rule verified in implementation)
+set -g @resurrect-processes '"~claude->claude --continue"'
+```
+
+- continuum auto-saves every 15 min by default (no extra config). A reboot loses at most
+  ~15 min of layout changes — acceptable.
+- `@continuum-restore 'on'` provides the chosen "restore on next tmux launch" behavior.
+
+### 3. Claude resume — the experimental piece (must be verified)
+
+Risk: the running pane process reports as its **version string** (e.g. `2.1.167`), not
+`claude` or `node`. resurrect relaunches by matching the saved process name, so the
+`@resurrect-processes '"~claude->claude --continue"'` rule (resurrect's "match loosely →
+restore with custom command" syntax) may not match.
+
+Verification + fallbacks, in order of preference:
+1. Confirm the `@resurrect-processes` arrow/tilde rule matches and relaunches
+   `claude --continue`. (Verify exact syntax against the resurrect README during
+   implementation.)
+2. If it doesn't match: a resurrect `@resurrect-hook-post-restore-all` script that
+   detects the claude panes and sends `claude --continue`.
+3. Worst case: restore shells in the correct cwd only; user runs `claude --continue`
+   (or the `/resume` picker) manually.
+
+Known caveat of `--continue`: it picks the most recent conversation for a directory. Two
+panes sharing one cwd would both resume the same conversation; distinct project dirs (the
+normal case here) map cleanly one-to-one.
+
+## Verification
+
+The real test, not just config review:
+1. Save state (`prefix + Ctrl-s`, or let continuum auto-save).
+2. `tmux kill-server`.
+3. Relaunch `tmux`.
+4. Confirm: windows/panes/layout restored, each pane in its prior cwd, scrollback visible,
+   and Claude Code panes resume the correct conversation.
+
+Not "done" until a session is observed coming back after a kill-server cycle.
+
+## Scope guard (YAGNI)
+
+- No `@continuum-boot` launchd agent (no auto-start at login).
+- No `--resume <session-id>` capture.
+- No restoring vim or other programs beyond the claude rule.
+- No changes to the other plugins' configuration.

--- a/docs/superpowers/specs/2026-06-07-tmux-session-persistence-design.md
+++ b/docs/superpowers/specs/2026-06-07-tmux-session-persistence-design.md
@@ -1,3 +1,17 @@
+---
+validated:
+  sha: 05651179c138c5ebab7f1173513b8152fe32bf4b
+  date: 2026-06-08T03:08:50Z
+  reviewers: [fact-check, solid-hygiene]
+  findings:
+    critical: 0
+    important: 0
+    medium: 0
+    low: 1
+    nitpick: 0
+  net_negative_remaining: 0
+---
+
 # Design: tmux session persistence across reboot
 
 **Date:** 2026-06-07
@@ -72,6 +86,13 @@ Verification + fallbacks, in order of preference:
 Known caveat of `--continue`: it picks the most recent conversation for a directory. Two
 panes sharing one cwd would both resume the same conversation; distinct project dirs (the
 normal case here) map cleanly one-to-one.
+
+> **Design note (2026-06-07):** The claude-restore behavior must have exactly one owner.
+> At implementation, commit to a single mechanism — the inline `@resurrect-processes` rule
+> OR the `@resurrect-hook-post-restore-all` script — and delete the unused half rather than
+> leaving both partially specified. Add a one-line comment in `tmux.conf` next to the chosen
+> mechanism so a future reader can find where claude-restore actually lives. The fallback
+> ladder above is a verification sequence, not a license to ship two dormant owners.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-06-09-tmux-claude-resume-design.md
+++ b/docs/superpowers/specs/2026-06-09-tmux-claude-resume-design.md
@@ -1,9 +1,23 @@
+---
+validated:
+  sha: 8dc69ad81c2e54591b3d6c08d8a4f0c6fcf3a048
+  date: 2026-06-09T19:15:31Z
+  reviewers: [fact-check, solid-hygiene]
+  findings:
+    critical: 0
+    important: 2
+    medium: 2
+    low: 9
+    nitpick: 0
+  net_negative_remaining: 0
+---
+
 # Design: bulletproof per-pane Claude Code resume across reboot
 
 **Date:** 2026-06-09
 **Status:** Approved
 **Branch:** ccc-config-1 (branch/PR strategy decided at implementation time)
-**Builds on:** tmux session persistence (`2026-06-07-tmux-session-persistence-design.md`, Tasks 1–3 shipped: continuum restore + resurrect pane-contents capture). Supersedes that plan's parked Tasks 4–5.
+**Builds on:** tmux session persistence (`2026-06-07-tmux-session-persistence-design.md`, Tasks 1–3 shipped: continuum restore + resurrect pane-contents capture). Supersedes the parked Claude-resume work — Tasks 4–5 of the *implementation plan* derived from that spec, not the design doc.
 
 ## Goal
 
@@ -31,8 +45,10 @@ sessions).
 - Sessions are stored at `~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl`; existence of
   that file confirms a session is resumable.
 - tmux-resurrect's save file records each pane's full command line (e.g.
-  `:claude --dangerously-skip-permissions -r`) and identifies panes by
-  `(session_name, window_index, pane_index)`.
+  `:claude --dangerously-skip-permissions -r` — empirically confirmed in a real save, not just
+  the bare command name) and identifies panes by `(session_name, window_index, pane_index)`.
+  That the command field carries the full launch line (with flags) is part of load-bearing
+  assumption #1 below.
 
 ## Architecture (B1: post-save rewrite)
 
@@ -47,26 +63,43 @@ must re-map freshly-assigned pane IDs).
 
 ### Components
 
-All scripts live in the dotfiles repo (public, generic). The hook registration is injected into
-`~/.claude/settings.json` by an idempotent installer — that file is personal and is **never
-committed**.
+All scripts live together in one repo feature directory `tmux-claude-resume/` (public, generic)
+— grouped so the feature's files and their shared contract sit in one place, and named
+distinctly from the repo's existing *project-local* `.claude/` tooling dir to avoid confusion.
+They deploy to stable paths under `~/.config/tmux-claude-resume/` via a `dotfiles.yaml` symlink
+entry (`~/.config/tmux-claude-resume/: tmux-claude-resume/*`), matching the repo's existing
+`~/.config/...` link convention — so nothing references a hardcoded repo-checkout path.
 
-1. **Capture hook — `claude/hooks/record-tmux-session.sh`**
+The hook registration is injected into the user's **global** `~/.claude/settings.json` by an
+idempotent installer. That file is personal and is **never committed**. Note: the repo also
+contains an *untracked, unrelated* project-local `.claude/settings.json` (this repo's own Claude
+config) — a distinct file at a different path. The installer targets the absolute
+`~/.claude/settings.json` and must not be conflated with the repo-local one.
+
+**Registry helper — `tmux-claude-resume/registry.sh` (single owner of the registry contract).**
+Defines, in exactly one place, the registry directory (`~/.cache/tmux-claude-resume/`), the
+`pane_id → filename` sanitization, the `session_id<TAB>cwd` line format, and read/write/prune
+functions. Both hooks source it, so a format change can't silently desync the two scripts into
+universal `-r` fallback.
+
+1. **Capture hook — `tmux-claude-resume/record-tmux-session.sh`** (deployed to
+   `~/.config/tmux-claude-resume/record-tmux-session.sh`)
    - Registered as a `SessionStart` hook (matchers `startup`, `resume`).
    - If `$TMUX` is unset → no-op (not in tmux).
-   - Else write `~/.cache/tmux-claude-resume/<sanitized-pane-id>` containing
-     `session_id<TAB>cwd` from `$CLAUDE_CODE_SESSION_ID`, `$TMUX_PANE`, `$PWD`.
+   - Else records `{pane_id → session_id, cwd}` **via the shared registry helper**, reading
+     `$CLAUDE_CODE_SESSION_ID`, `$TMUX_PANE`, `$PWD`. (Does not hand-roll the path/format.)
    - Idempotent; overwrites on every start/resume so the entry is always current.
    - Inputs: env vars. Output: one registry file. Independently testable.
 
-2. **Injection hook — `tmux/resurrect-inject-claude-resume.sh`**
+2. **Injection hook — `tmux-claude-resume/resurrect-inject-claude-resume.sh`** (deployed to
+   `~/.config/tmux-claude-resume/resurrect-inject-claude-resume.sh`)
    - Wired via `@resurrect-hook-post-save-all`. Runs after resurrect writes its save file.
    - Resolves the save file (`<@resurrect-dir>/last`).
    - Builds a live join table: `tmux list-panes -a -F
      '#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_id}'`.
    - For each save-file `pane` line whose command field contains `claude`:
      - Find `pane_id` via the join on `(session_name, window_index, pane_index)`.
-     - Look up `session_id` in the registry by `pane_id`.
+     - Look up `session_id` **via the shared registry helper**, keyed by `pane_id`.
      - If found AND `~/.claude/projects/<slug>/<session_id>.jsonl` exists → rewrite command to
        `claude <preserved-flags> --resume <session_id>`.
      - Else → rewrite to `claude <preserved-flags> -r` (the chosen fallback).
@@ -78,11 +111,24 @@ committed**.
 
 3. **tmux.conf additions** (in the existing persistence block):
    - `set -g @resurrect-processes '~claude'` (so resurrect restores claude panes at all).
-   - `set -g @resurrect-hook-post-save-all 'bash <repo>/tmux/resurrect-inject-claude-resume.sh'`.
+   - `set -g @resurrect-hook-post-save-all 'bash ~/.config/tmux-claude-resume/resurrect-inject-claude-resume.sh'`
+     — the deployed symlink path, so the committed `tmux.conf` carries no hardcoded
+     repo-checkout location (consistent with the rest of the file using `$HOME`/`~` paths).
 
-4. **Installer** — idempotently merges the `SessionStart` hook entry into
-   `~/.claude/settings.json` (jq or python), skipping if already present. Does not commit
-   settings.json.
+4. **Installer** — idempotently merges the `SessionStart` hook entry into the absolute
+   `~/.claude/settings.json` (jq or python), skipping if already present; never a relative
+   `.claude/settings.json` (which would hit the repo-local file). Does not commit settings.json.
+   Deployment of the scripts themselves is handled by the new `dotfiles.yaml` link entry
+   (`~/.config/tmux-claude-resume/: tmux-claude-resume/*`) run via `./dot.py link`, keeping
+   deployment single-mechanism rather than an installer-managed side path.
+
+> **Design note (2026-06-09, validate):** Reviewer feedback tightened three seams in this
+> section: (1) the registry is now a **single-owner contract** (`registry.sh` sourced by both
+> hooks) instead of a format duplicated across two scripts; (2) script **deployment is defined**
+> — one feature dir `tmux-claude-resume/` symlinked to `~/.config/tmux-claude-resume/` via
+> `dotfiles.yaml`, with no hardcoded repo-checkout path in the committed `tmux.conf`; (3) the
+> installer targets the **absolute** `~/.claude/settings.json`, explicitly distinct from the
+> repo's untracked project-local `.claude/settings.json`.
 
 ### Data flow
 
@@ -108,7 +154,10 @@ resumes its own conversation.
 2. `@resurrect-hook-post-save-all` fires after save, with the save file resolvable.
 
 If either is false, fall back to architecture B2 (post-restore keystroke injection) — but only
-after the spikes, not speculatively.
+after the spikes, not speculatively. Switching to B2 discards Components 2–3 (the injection hook
+and the `@resurrect-*` wiring) and changes the testing strategy; the capture hook (Component 1)
+and the registry helper survive unchanged. Therefore do NOT build Components 2–3 until
+assumption #1 is confirmed — the spike gates a possible redesign, not a tweak.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-09-tmux-claude-resume-design.md
+++ b/docs/superpowers/specs/2026-06-09-tmux-claude-resume-design.md
@@ -1,0 +1,131 @@
+# Design: bulletproof per-pane Claude Code resume across reboot
+
+**Date:** 2026-06-09
+**Status:** Approved
+**Branch:** ccc-config-1 (branch/PR strategy decided at implementation time)
+**Builds on:** tmux session persistence (`2026-06-07-tmux-session-persistence-design.md`, Tasks 1–3 shipped: continuum restore + resurrect pane-contents capture). Supersedes that plan's parked Tasks 4–5.
+
+## Goal
+
+After a reboot, each restored tmux pane that was running Claude Code resumes **its own exact
+conversation** by session ID — not "the most recent conversation in the directory." This
+eliminates the same-cwd collision (two panes in one directory must resume two different
+sessions).
+
+## Why the obvious approaches don't work
+
+- **`claude --continue`** resumes the most-recent conversation *per directory* → two panes
+  sharing a cwd collide. (Real in the user's layout: multiple panes in
+  `/Users/stavxyz/src/stavxyz-agent`.)
+- **tmux-resurrect alone** only records the command that *launched* each pane. Panes launched
+  with `-r` (interactive picker) don't carry a session ID, so resurrect can only replay `-r`.
+- **`lsof`** on a running claude pid shows no open session `.jsonl` → can't map pane→session
+  that way.
+
+## Key enabling facts (verified)
+
+- `CLAUDE_CODE_SESSION_ID` IS present in the environment of Claude Code child processes
+  (confirmed: it equals the live session UUID). A Claude Code **hook** runs as a child, so it
+  can read both `$CLAUDE_CODE_SESSION_ID` and `$TMUX_PANE`.
+- `claude --resume <id>` deterministically reattaches to exactly that session.
+- Sessions are stored at `~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl`; existence of
+  that file confirms a session is resumable.
+- tmux-resurrect's save file records each pane's full command line (e.g.
+  `:claude --dangerously-skip-permissions -r`) and identifies panes by
+  `(session_name, window_index, pane_index)`.
+
+## Architecture (B1: post-save rewrite)
+
+Capture the live pane→session mapping via a Claude hook; at resurrect save time, rewrite the
+save file so each claude pane's restore command becomes `claude <flags> --resume <id>`.
+resurrect's normal restore then replays it — the ID is baked into the saved artifact, so there
+are no restore-time races.
+
+Alternatives rejected: a PATH wrapper shadowing `claude` (too invasive; affects every
+invocation; create≠resume translation), and post-restore keystroke injection (timing-fragile;
+must re-map freshly-assigned pane IDs).
+
+### Components
+
+All scripts live in the dotfiles repo (public, generic). The hook registration is injected into
+`~/.claude/settings.json` by an idempotent installer — that file is personal and is **never
+committed**.
+
+1. **Capture hook — `claude/hooks/record-tmux-session.sh`**
+   - Registered as a `SessionStart` hook (matchers `startup`, `resume`).
+   - If `$TMUX` is unset → no-op (not in tmux).
+   - Else write `~/.cache/tmux-claude-resume/<sanitized-pane-id>` containing
+     `session_id<TAB>cwd` from `$CLAUDE_CODE_SESSION_ID`, `$TMUX_PANE`, `$PWD`.
+   - Idempotent; overwrites on every start/resume so the entry is always current.
+   - Inputs: env vars. Output: one registry file. Independently testable.
+
+2. **Injection hook — `tmux/resurrect-inject-claude-resume.sh`**
+   - Wired via `@resurrect-hook-post-save-all`. Runs after resurrect writes its save file.
+   - Resolves the save file (`<@resurrect-dir>/last`).
+   - Builds a live join table: `tmux list-panes -a -F
+     '#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_id}'`.
+   - For each save-file `pane` line whose command field contains `claude`:
+     - Find `pane_id` via the join on `(session_name, window_index, pane_index)`.
+     - Look up `session_id` in the registry by `pane_id`.
+     - If found AND `~/.claude/projects/<slug>/<session_id>.jsonl` exists → rewrite command to
+       `claude <preserved-flags> --resume <session_id>`.
+     - Else → rewrite to `claude <preserved-flags> -r` (the chosen fallback).
+     - "Preserved flags" = the saved command minus any existing `-r`/`--resume <x>`/`-c`/
+       `--continue` (e.g. `--dangerously-skip-permissions` is kept).
+   - Prunes registry entries whose pane no longer exists.
+   - Inputs: save file + live panes + registry. Output: rewritten save file. Testable with
+     fixtures.
+
+3. **tmux.conf additions** (in the existing persistence block):
+   - `set -g @resurrect-processes '~claude'` (so resurrect restores claude panes at all).
+   - `set -g @resurrect-hook-post-save-all 'bash <repo>/tmux/resurrect-inject-claude-resume.sh'`.
+
+4. **Installer** — idempotently merges the `SessionStart` hook entry into
+   `~/.claude/settings.json` (jq or python), skipping if already present. Does not commit
+   settings.json.
+
+### Data flow
+
+claude starts/resumes in a pane → capture hook records `pane→session_id` → continuum auto-saves
+(every 15 min) or manual save → post-save hook bakes `--resume <id>` (or `-r`) per claude pane →
+reboot → continuum-restore replays the save file → each pane runs `claude … --resume <id>` and
+resumes its own conversation.
+
+### Edge cases / error handling
+
+- Not in tmux → capture hook no-ops.
+- No captured id, or session `.jsonl` aged out (Claude's 30-day cleanup) → restore command is
+  `claude <flags> -r` (picker).
+- Stale registry entries (closed panes) → pruned at save time.
+- Multiple sessions over a pane's life → registry holds the latest (the active one). Correct.
+- A saved `--resume <id>` whose session disappears between save and reboot → claude opens the
+  picker. Acceptable.
+
+## Load-bearing assumptions to verify first (spikes, before building)
+
+1. tmux-resurrect replays the save file's command field for `~`-matched processes (so rewriting
+   the field changes what gets launched).
+2. `@resurrect-hook-post-save-all` fires after save, with the save file resolvable.
+
+If either is false, fall back to architecture B2 (post-restore keystroke injection) — but only
+after the spikes, not speculatively.
+
+## Testing
+
+- **Capture hook:** invoke with `TMUX`, `TMUX_PANE`, `CLAUDE_CODE_SESSION_ID`, `PWD` set; assert
+  the registry file contents. Assert no-op when `$TMUX` unset.
+- **Injection hook:** fixture a synthetic resurrect save file + a synthetic registry + a stub
+  pane-join; assert mapped claude lines become `--resume <id>`, unmapped become `-r`, non-claude
+  lines untouched, and other flags preserved.
+- **Installer:** run twice; assert the hook is present once (idempotent) and unrelated
+  settings.json keys are untouched.
+- bats tests under `tests/`.
+- **Manual gated E2E:** real claude panes (incl. two sharing a cwd) → save → `tmux kill-server`
+  → restart → verify each pane resumed its *own* session.
+
+## Scope / YAGNI
+
+- tmux + Claude Code only. No cross-machine sync. No GUI.
+- `~/.claude/settings.json` is injected idempotently, never committed.
+- Reuses the continuum/resurrect machinery already enabled in Tasks 1–3; does not re-implement
+  save/restore.

--- a/dotfiles.yaml
+++ b/dotfiles.yaml
@@ -44,6 +44,7 @@ links:
     ~/.config/karabiner/karabiner.json:     karabiner/karabiner.json
     ~/.inputrc:                             osx/inputrc
     ~/.config/base16-shell:                 shell/base16-shell
+    ~/.config/tmux-claude-resume/:          tmux-claude-resume/*
 
 brew:
     install:

--- a/install.sh
+++ b/install.sh
@@ -9,12 +9,14 @@
 #
 # Prerequisites installed:
 # - vim-plug (Vim plugin manager)
+# - TPM (tmux plugin manager)
 # - pyenv (Python version manager via pyenv-installer)
 # - pyenv-virtualenvwrapper (Python virtual environment tools)
 #
 # Note: This script only installs missing components. It does not update
 # existing installations. Use the appropriate update method for each tool:
 #   - vim-plug: Run :PlugUpdate in Vim
+#   - TPM: Run `prefix + U` inside tmux to update plugins
 #   - pyenv: Run `pyenv update` (if installed via pyenv-installer) or `brew upgrade pyenv`
 #   - pyenv-virtualenvwrapper: `cd $(pyenv root)/plugins/pyenv-virtualenvwrapper && git pull`
 #
@@ -42,6 +44,17 @@ else
     echo "Installing vim-plug..."
     curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
         https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+fi
+
+# ============================================================================
+# TMUX Plugin Manager (TPM)
+# ============================================================================
+
+if [[ -d ~/.tmux/plugins/tpm ]]; then
+    echo "✓ TPM (tmux plugin manager) already installed"
+else
+    echo "Installing TPM (tmux plugin manager)..."
+    git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
 fi
 
 # ============================================================================
@@ -89,4 +102,5 @@ echo ""
 echo "Next steps:"
 echo "  1. Restart your terminal (to load pyenv)"
 echo "  2. Run: ./dot.py link"
+echo "  3. Inside tmux, press 'prefix + I' to install tmux plugins"
 echo ""

--- a/tests/test-baseline.bats
+++ b/tests/test-baseline.bats
@@ -4,7 +4,7 @@
 
 setup() {
     # Dynamically detect dotfiles directory
-    export DOTFILES_DIR="$(cd "$(dirname "$BATS_TEST_DIRNAME")/.." && pwd)"
+    export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     export RESULTS_FILE="${HOME}/.cache/dotfiles/baseline-results.txt"
     mkdir -p "$(dirname "$RESULTS_FILE")"
 }
@@ -21,9 +21,11 @@ setup() {
 }
 
 @test "aliases are defined" {
-    run bash -l -c 'alias | wc -l'
+    # Count actual alias definitions; tolerate any login-banner output on stdout
+    # (a login shell may print a banner, which would otherwise pollute a bare line count).
+    run bash -l -c 'alias'
     [ "$status" -eq 0 ]
-    [ "$output" -gt 0 ]
+    [ "$(printf '%s\n' "$output" | grep -c '^alias ')" -gt 0 ]
 }
 
 @test "PATH is set correctly" {

--- a/tests/test-benchmark.bats
+++ b/tests/test-benchmark.bats
@@ -4,7 +4,7 @@
 
 setup() {
     # Dynamically detect dotfiles directory
-    export DOTFILES_DIR="$(cd "$(dirname "$BATS_TEST_DIRNAME")/.." && pwd)"
+    export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     export BENCHMARK_FILE="${HOME}/.cache/dotfiles/benchmark-results.txt"
     mkdir -p "$(dirname "$BENCHMARK_FILE")"
 }

--- a/tests/test-tmux-claude-capture.bats
+++ b/tests/test-tmux-claude-capture.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+# Test: tmux-claude-resume SessionStart capture hook
+
+setup() {
+    export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export TMUX_CLAUDE_RESUME_DIR="$(mktemp -d)"
+    export HOOK="$DOTFILES_DIR/tmux-claude-resume/record-tmux-session.sh"
+}
+teardown() { rm -rf "$TMUX_CLAUDE_RESUME_DIR"; }
+
+@test "records the mapping when in tmux with a session id" {
+    run env TMUX="/tmp/x,1,0" TMUX_PANE="%3" CLAUDE_CODE_SESSION_ID="sess-1" \
+        PWD="/tmp/proj" TMUX_CLAUDE_RESUME_DIR="$TMUX_CLAUDE_RESUME_DIR" bash "$HOOK"
+    [ "$status" -eq 0 ]
+    source "$DOTFILES_DIR/tmux-claude-resume/registry.sh"
+    run tcr_session_id "%3"
+    [ "$output" = "sess-1" ]
+}
+
+@test "no-op when not in tmux (TMUX unset)" {
+    run env -u TMUX TMUX_PANE="%3" CLAUDE_CODE_SESSION_ID="sess-1" \
+        TMUX_CLAUDE_RESUME_DIR="$TMUX_CLAUDE_RESUME_DIR" bash "$HOOK"
+    [ "$status" -eq 0 ]
+    [ -z "$(ls -A "$TMUX_CLAUDE_RESUME_DIR" 2>/dev/null)" ]
+}
+
+@test "no-op when CLAUDE_CODE_SESSION_ID is missing" {
+    # -u must precede name=value pairs on macOS env
+    run env -u CLAUDE_CODE_SESSION_ID TMUX="/tmp/x,1,0" TMUX_PANE="%3" \
+        TMUX_CLAUDE_RESUME_DIR="$TMUX_CLAUDE_RESUME_DIR" bash "$HOOK"
+    [ "$status" -eq 0 ]
+    [ -z "$(ls -A "$TMUX_CLAUDE_RESUME_DIR" 2>/dev/null)" ]
+}

--- a/tests/test-tmux-claude-inject.bats
+++ b/tests/test-tmux-claude-inject.bats
@@ -56,3 +56,13 @@ teardown() { rm -rf "$WORK"; }
     run grep -c ':vim$' "$RESDIR/last"
     [ "$output" = "1" ]
 }
+
+@test "duplicate flags are collapsed (Claude re-adds --dangerously-skip-permissions each launch)" {
+    # A pane whose captured command already accumulated the flag (doubled/tripled).
+    printf 'pane\tmain\t1\t0\t:\t0\t title\t:/tmp/proj\t1\t2.1.168\t:claude --dangerously-skip-permissions --dangerously-skip-permissions --dangerously-skip-permissions -r\n' > "$RESDIR/last"
+    HOME="$FAKE_HOME" run bash "$INJECT"
+    [ "$status" -eq 0 ]
+    # Exactly one --dangerously-skip-permissions, then --resume <id>.
+    run grep -c ':claude --dangerously-skip-permissions --resume live-sess$' "$RESDIR/last"
+    [ "$output" = "1" ]
+}

--- a/tests/test-tmux-claude-inject.bats
+++ b/tests/test-tmux-claude-inject.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+# Test: tmux-claude-resume resurrect post-save injection
+
+setup() {
+    export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export WORK="$(mktemp -d)"
+    export TMUX_CLAUDE_RESUME_DIR="$WORK/registry"
+    export RESDIR="$WORK/resurrect"
+    export FAKE_HOME="$WORK/home"
+    mkdir -p "$RESDIR" "$FAKE_HOME/.claude/projects/-tmp-proj"
+    export INJECT="$DOTFILES_DIR/tmux-claude-resume/resurrect-inject-claude-resume.sh"
+
+    # Stub tmux: answer the queries the script makes.
+    mkdir -p "$WORK/bin"
+    cat > "$WORK/bin/tmux" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  "show-options -gv @resurrect-dir") echo "$RESDIR" ;;
+  "list-panes -a -F #{pane_id}") printf '%%1\n%%2\n' ;;
+  "list-panes -a -F"*) printf 'main\t1\t0\t%%1\nmain\t1\t1\t%%2\n' ;;
+  *) exit 0 ;;
+esac
+EOF
+    chmod +x "$WORK/bin/tmux"
+    export PATH="$WORK/bin:$PATH"
+
+    # Registry: pane %1 -> session WITH a jsonl; pane %2 -> session WITHOUT jsonl.
+    source "$DOTFILES_DIR/tmux-claude-resume/registry.sh"
+    tcr_record "%1" "live-sess" "/tmp/proj"
+    tcr_record "%2" "dead-sess" "/tmp/proj"
+    : > "$FAKE_HOME/.claude/projects/-tmp-proj/live-sess.jsonl"   # exists
+    # dead-sess.jsonl intentionally absent
+
+    # Save file: pane %1 (session exists), pane %2 (session gone), and a non-claude pane.
+    printf 'pane\tmain\t1\t0\t:\t0\t title\t:/tmp/proj\t1\t2.1.168\t:claude --dangerously-skip-permissions -r\n'  > "$RESDIR/last"
+    printf 'pane\tmain\t1\t0\t:\t1\t title\t:/tmp/proj\t0\t2.1.168\t:claude --dangerously-skip-permissions -r\n' >> "$RESDIR/last"
+    printf 'pane\tmain\t1\t0\t:\t2\t title\t:/tmp/proj\t0\tvim\t:vim\n'                                          >> "$RESDIR/last"
+}
+teardown() { rm -rf "$WORK"; }
+
+@test "pane with a live session is rewritten to --resume <id>, flags preserved" {
+    HOME="$FAKE_HOME" run bash "$INJECT"
+    [ "$status" -eq 0 ]
+    run grep -c ':claude --dangerously-skip-permissions --resume live-sess$' "$RESDIR/last"
+    [ "$output" = "1" ]
+}
+
+@test "pane whose session is gone falls back to -r, flags preserved" {
+    HOME="$FAKE_HOME" run bash "$INJECT"
+    run grep -c ':claude --dangerously-skip-permissions -r$' "$RESDIR/last"
+    [ "$output" = "1" ]
+}
+
+@test "non-claude pane line is left untouched" {
+    HOME="$FAKE_HOME" run bash "$INJECT"
+    run grep -c ':vim$' "$RESDIR/last"
+    [ "$output" = "1" ]
+}

--- a/tests/test-tmux-claude-inject.bats
+++ b/tests/test-tmux-claude-inject.bats
@@ -57,6 +57,19 @@ teardown() { rm -rf "$WORK"; }
     [ "$output" = "1" ]
 }
 
+@test "adjacent resume-family flags are fully stripped (no contradictory leftover)" {
+    # Two resume-family flags in a row must BOTH be removed before --resume <id> is appended;
+    # a single non-looped sed pass would leave the second (shared separator gets consumed).
+    printf 'pane\tmain\t1\t0\t:\t0\t title\t:/tmp/proj\t1\t2.1.168\t:claude --dangerously-skip-permissions --resume oldid -c\n' > "$RESDIR/last"
+    HOME="$FAKE_HOME" run bash "$INJECT"
+    [ "$status" -eq 0 ]
+    run grep -c ':claude --dangerously-skip-permissions --resume live-sess$' "$RESDIR/last"
+    [ "$output" = "1" ]
+    # no stray -c / -r / old id left behind
+    run grep -cE 'oldid| -c$| -c | -r$| -r ' "$RESDIR/last"
+    [ "$output" = "0" ]
+}
+
 @test "duplicate flags are collapsed (Claude re-adds --dangerously-skip-permissions each launch)" {
     # A pane whose captured command already accumulated the flag (doubled/tripled).
     printf 'pane\tmain\t1\t0\t:\t0\t title\t:/tmp/proj\t1\t2.1.168\t:claude --dangerously-skip-permissions --dangerously-skip-permissions --dangerously-skip-permissions -r\n' > "$RESDIR/last"

--- a/tests/test-tmux-claude-install.bats
+++ b/tests/test-tmux-claude-install.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+# Test: tmux-claude-resume settings.json hook installer (idempotent merge)
+
+setup() {
+    export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export FAKE_HOME="$(mktemp -d)"
+    mkdir -p "$FAKE_HOME/.claude"
+    # pre-existing unrelated settings to prove we don't clobber
+    printf '{"model":"opus","hooks":{}}\n' > "$FAKE_HOME/.claude/settings.json"
+    export INSTALL="$DOTFILES_DIR/tmux-claude-resume/install-hook.sh"
+}
+teardown() { rm -rf "$FAKE_HOME"; }
+
+@test "adds the SessionStart hook and preserves unrelated keys" {
+    HOME="$FAKE_HOME" run bash "$INSTALL"
+    [ "$status" -eq 0 ]
+    run jq -r '.model' "$FAKE_HOME/.claude/settings.json"
+    [ "$output" = "opus" ]
+    run jq '[.hooks.SessionStart[].hooks[].command] | map(select(test("record-tmux-session.sh"))) | length' "$FAKE_HOME/.claude/settings.json"
+    [ "$output" = "1" ]
+}
+
+@test "running twice is idempotent (hook present exactly once)" {
+    HOME="$FAKE_HOME" bash "$INSTALL"
+    HOME="$FAKE_HOME" run bash "$INSTALL"
+    [ "$status" -eq 0 ]
+    run jq '[.. | objects | .command? // empty | select(test("record-tmux-session.sh"))] | length' "$FAKE_HOME/.claude/settings.json"
+    [ "$output" = "1" ]
+}

--- a/tests/test-tmux-claude-install.bats
+++ b/tests/test-tmux-claude-install.bats
@@ -27,3 +27,13 @@ teardown() { rm -rf "$FAKE_HOME"; }
     run jq '[.. | objects | .command? // empty | select(test("record-tmux-session.sh"))] | length' "$FAKE_HOME/.claude/settings.json"
     [ "$output" = "1" ]
 }
+
+@test "corrupt settings.json: clear error, exits non-zero, file left untouched" {
+    printf 'this is { not json' > "$FAKE_HOME/.claude/settings.json"
+    HOME="$FAKE_HOME" run bash "$INSTALL"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not valid JSON"* ]]
+    # original (corrupt) content is preserved, not clobbered
+    run cat "$FAKE_HOME/.claude/settings.json"
+    [ "$output" = "this is { not json" ]
+}

--- a/tests/test-tmux-claude-registry.bats
+++ b/tests/test-tmux-claude-registry.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# Test: tmux-claude-resume registry helper
+
+setup() {
+    export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export TMUX_CLAUDE_RESUME_DIR="$(mktemp -d)"
+    source "$DOTFILES_DIR/tmux-claude-resume/registry.sh"
+}
+teardown() { rm -rf "$TMUX_CLAUDE_RESUME_DIR"; }
+
+@test "record then lookup returns the session id" {
+    tcr_record "%5" "abc-123" "/tmp/proj"
+    run tcr_session_id "%5"
+    [ "$status" -eq 0 ]
+    [ "$output" = "abc-123" ]
+}
+
+@test "lookup of unknown pane prints nothing, exits 0" {
+    run tcr_session_id "%9"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "record overwrites the prior mapping for a pane" {
+    tcr_record "%5" "old-id" "/tmp/a"
+    tcr_record "%5" "new-id" "/tmp/b"
+    run tcr_session_id "%5"
+    [ "$output" = "new-id" ]
+}
+
+@test "prune removes entries whose pane is not in the live set" {
+    tcr_record "%1" "s1" "/tmp/1"
+    tcr_record "%2" "s2" "/tmp/2"
+    tcr_prune "%1"
+    run tcr_session_id "%1"; [ "$output" = "s1" ]
+    run tcr_session_id "%2"; [ -z "$output" ]
+}

--- a/tests/test-tmux-persistence.bats
+++ b/tests/test-tmux-persistence.bats
@@ -30,3 +30,15 @@ teardown() {
     [ "$status" -eq 0 ]
     [ "$output" = "on" ]
 }
+
+@test "resurrect treats claude as a restorable process" {
+    run tmux -L "$SOCKET" show-options -gv @resurrect-processes
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"~claude"* ]]
+}
+
+@test "resurrect post-save hook points at the deployed injection script" {
+    run tmux -L "$SOCKET" show-options -gv @resurrect-hook-post-save-all
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tmux-claude-resume/resurrect-inject-claude-resume.sh"* ]]
+}

--- a/tests/test-tmux-persistence.bats
+++ b/tests/test-tmux-persistence.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+# Test: tmux session persistence
+# Description: Assert resurrect/continuum persistence options are set by tmux.conf
+
+setup() {
+    # NOTE: single '..' resolves to the repo root. The existing tests/*.bats use
+    # $(dirname "$BATS_TEST_DIRNAME")/.. which resolves ABOVE the repo — do not copy that form here.
+    export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export TMUX_CONF="$DOTFILES_DIR/tmux/tmux.conf"
+    export SOCKET="tmux-persistence-test-$$"
+    # Unset ITERM_PROFILE so the solarized if-shell source lines are skipped.
+    unset ITERM_PROFILE
+    tmux -L "$SOCKET" kill-server 2>/dev/null || true
+    tmux -L "$SOCKET" -f /dev/null new-session -d -x 200 -y 50
+    tmux -L "$SOCKET" source-file "$TMUX_CONF"
+}
+
+teardown() {
+    tmux -L "$SOCKET" kill-server 2>/dev/null || true
+}
+
+@test "continuum auto-restore is enabled" {
+    run tmux -L "$SOCKET" show-options -gv @continuum-restore
+    [ "$status" -eq 0 ]
+    [ "$output" = "on" ]
+}
+
+@test "resurrect captures pane contents" {
+    run tmux -L "$SOCKET" show-options -gv @resurrect-capture-pane-contents
+    [ "$status" -eq 0 ]
+    [ "$output" = "on" ]
+}

--- a/tests/test-validate.bats
+++ b/tests/test-validate.bats
@@ -4,7 +4,7 @@
 
 setup() {
     # Dynamically detect dotfiles directory
-    export DOTFILES_DIR="$(cd "$(dirname "$BATS_TEST_DIRNAME")/.." && pwd)"
+    export DOTFILES_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
 }
 
 @test "bash profile loads without errors" {

--- a/tmux-claude-resume/README.md
+++ b/tmux-claude-resume/README.md
@@ -1,0 +1,72 @@
+# tmux-claude-resume
+
+Make each tmux pane resume **its own** Claude Code conversation after a reboot.
+
+tmux-resurrect/continuum already restore your windows, panes, layout, and working
+directories across a reboot. But a restored pane only knows the command that *launched*
+it — so a pane started with `claude -r` (the resume picker) just reopens the picker, and
+`claude --continue` resumes "the most recent conversation in the directory," which
+**collides** when two panes share a working directory. This feature closes that gap: every
+restored Claude pane reattaches to the exact session it was on, by session ID.
+
+## How it works
+
+Three small bash units, plus two tmux options:
+
+1. **`record-tmux-session.sh`** — a Claude Code `SessionStart` hook. It runs inside each
+   pane (so it sees `$CLAUDE_CODE_SESSION_ID` and `$TMUX_PANE`) and records a
+   `pane → session_id` mapping. No-op outside tmux.
+2. **`registry.sh`** — the single owner of the registry schema (one file per pane under
+   `~/.cache/tmux-claude-resume/`, holding `session_id<TAB>cwd`). Both hooks source it.
+3. **`resurrect-inject-claude-resume.sh`** — a tmux-resurrect `@resurrect-hook-post-save-all`
+   hook. After each save it rewrites every claude pane's saved command to
+   `claude <your-flags> --resume <id>`, looking the ID up by joining the save file's
+   `(session, window, pane_index)` to the live panes and then to the registry. Your other
+   flags (e.g. `--dangerously-skip-permissions`) are preserved.
+
+Flow: claude starts → hook records the pane's session → continuum auto-saves (every 15 min)
+→ the post-save hook bakes `--resume <id>` into the save file → reboot → continuum restores
+→ each pane runs `claude … --resume <id>` and resumes its own conversation.
+
+**Fallback:** if a pane's session ID isn't known or its transcript no longer exists
+(`~/.claude/projects/<cwd>/<id>.jsonl` is gone — e.g. Claude's 30-day cleanup), that pane
+falls back to `claude … -r` (the resume picker). Never the wrong conversation.
+
+## Enable it
+
+Prerequisites: `tmux-resurrect` + `tmux-continuum` installed (via TPM: `prefix + I`), `jq`,
+and Claude Code. The persistence options live in `tmux/tmux.conf` already.
+
+```bash
+./dot.py link                                       # symlinks scripts into ~/.config/tmux-claude-resume/
+bash ~/.config/tmux-claude-resume/install-hook.sh   # registers the SessionStart hook in ~/.claude/settings.json
+tmux source-file ~/.tmux.conf
+```
+
+`install-hook.sh` is idempotent and only touches the global `~/.claude/settings.json`
+(never a repo-local `.claude/settings.json`). That's it — start using Claude in tmux panes
+and they'll be recorded automatically.
+
+## Verify
+
+Start `claude` in two panes sharing one directory, then:
+
+```bash
+cat ~/.cache/tmux-claude-resume/*   # distinct session ids per pane
+tmux run-shell ~/.tmux/plugins/tmux-resurrect/scripts/save.sh
+grep claude "$(tmux show-options -gv @resurrect-dir 2>/dev/null || echo ~/.tmux/resurrect)/last"
+# each claude pane line ends with its own `--resume <id>`
+tmux kill-server && tmux             # continuum auto-restores → each pane resumes its own conversation
+```
+
+## Files
+
+| File | Role |
+|------|------|
+| `registry.sh` | Single-owner registry schema (path, key sanitization, record/lookup/prune) |
+| `record-tmux-session.sh` | Claude `SessionStart` hook — records `pane → session_id` |
+| `resurrect-inject-claude-resume.sh` | resurrect post-save hook — rewrites restore commands |
+| `install-hook.sh` | Idempotent installer for the `SessionStart` hook |
+
+Tests live in `tests/test-tmux-claude-*.bats`. Design docs:
+`docs/superpowers/specs/2026-06-09-tmux-claude-resume-design.md` and the matching plan.

--- a/tmux-claude-resume/install-hook.sh
+++ b/tmux-claude-resume/install-hook.sh
@@ -9,6 +9,13 @@ cmd="$HOME/.config/tmux-claude-resume/record-tmux-session.sh"
 mkdir -p "$(dirname "$settings")"
 [ -f "$settings" ] || echo '{}' > "$settings"
 
+# Refuse to touch a settings file that isn't valid JSON, with a clear message
+# (rather than letting jq emit a cryptic parse error). The file is left as-is.
+if ! jq -e . "$settings" > /dev/null 2>&1; then
+    echo "error: $settings is not valid JSON; aborting (left untouched)" >&2
+    exit 1
+fi
+
 # Already present? Then this is a no-op.
 if jq -e --arg c "$cmd" \
     '[.. | objects | .command? // empty] | any(. == $c)' "$settings" > /dev/null; then

--- a/tmux-claude-resume/install-hook.sh
+++ b/tmux-claude-resume/install-hook.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Idempotently register the tmux-claude-resume SessionStart hook in the user's
+# GLOBAL ~/.claude/settings.json. Never touches any repo-local .claude/settings.json.
+set -euo pipefail
+
+settings="$HOME/.claude/settings.json"
+cmd="$HOME/.config/tmux-claude-resume/record-tmux-session.sh"
+
+mkdir -p "$(dirname "$settings")"
+[ -f "$settings" ] || echo '{}' > "$settings"
+
+# Already present? Then this is a no-op.
+if jq -e --arg c "$cmd" \
+    '[.. | objects | .command? // empty] | any(. == $c)' "$settings" > /dev/null; then
+    echo "tmux-claude-resume hook already installed"
+    exit 0
+fi
+
+tmp="$(mktemp)"
+jq --arg c "$cmd" '
+    .hooks //= {} |
+    .hooks.SessionStart //= [] |
+    .hooks.SessionStart += [{
+        "matcher": "startup|resume",
+        "hooks": [{ "type": "command", "command": $c }]
+    }]
+' "$settings" > "$tmp"
+mv "$tmp" "$settings"
+echo "tmux-claude-resume hook installed in $settings"

--- a/tmux-claude-resume/record-tmux-session.sh
+++ b/tmux-claude-resume/record-tmux-session.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Claude Code SessionStart hook. Records this pane's session id so tmux-resurrect
+# can later relaunch the pane with `claude --resume <id>`. No-op outside tmux.
+set -euo pipefail
+
+# Need all three identifiers; otherwise we cannot (or should not) record.
+[ -n "${TMUX:-}" ] || exit 0
+[ -n "${TMUX_PANE:-}" ] || exit 0
+[ -n "${CLAUDE_CODE_SESSION_ID:-}" ] || exit 0
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=registry.sh
+source "$here/registry.sh"
+
+tcr_record "$TMUX_PANE" "$CLAUDE_CODE_SESSION_ID" "$PWD"

--- a/tmux-claude-resume/registry.sh
+++ b/tmux-claude-resume/registry.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Single source of truth for the tmux-claude-resume pane->session registry.
+# Schema: one file per tmux pane under the registry dir, named by a sanitized
+# pane id, containing a single line: "<session_id>\t<cwd>".
+# The cwd field is diagnostic/reserved — no consumer reads it today; only field 1
+# (session_id) is load-bearing. Override the dir with $TMUX_CLAUDE_RESUME_DIR (tests).
+# Prune contract: tcr_prune requires a NON-EMPTY live-pane set (see resurrect-inject).
+
+tcr_registry_dir() {
+    echo "${TMUX_CLAUDE_RESUME_DIR:-$HOME/.cache/tmux-claude-resume}"
+}
+
+# Map a tmux pane id (e.g. "%5") to a safe filename (e.g. "pane_5").
+tcr_pane_key() {
+    printf 'pane_%s' "${1//[^A-Za-z0-9]/_}"
+}
+
+# Record (overwrite) the mapping for a pane.
+tcr_record() {
+    local pane="$1" session_id="$2" cwd="$3" dir
+    dir="$(tcr_registry_dir)"
+    mkdir -p "$dir"
+    printf '%s\t%s\n' "$session_id" "$cwd" > "$dir/$(tcr_pane_key "$pane")"
+}
+
+# Print the session id recorded for a pane (nothing if absent). Always exits 0.
+tcr_session_id() {
+    local file
+    file="$(tcr_registry_dir)/$(tcr_pane_key "$1")"
+    [ -f "$file" ] || return 0
+    cut -f1 "$file"
+}
+
+# Remove registry files whose pane is not in the given live-pane list.
+# Usage: tcr_prune "%1" "%2" ...
+tcr_prune() {
+    local dir f base; dir="$(tcr_registry_dir)"
+    [ -d "$dir" ] || return 0
+    declare -A keep=()
+    local p; for p in "$@"; do keep["$(tcr_pane_key "$p")"]=1; done
+    for f in "$dir"/pane_*; do
+        [ -e "$f" ] || continue
+        base="$(basename "$f")"
+        [ -n "${keep[$base]:-}" ] || rm -f "$f"
+    done
+}

--- a/tmux-claude-resume/resurrect-inject-claude-resume.sh
+++ b/tmux-claude-resume/resurrect-inject-claude-resume.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# tmux-resurrect @resurrect-hook-post-save-all hook.
+# Rewrites each claude pane's restore command in the just-saved file to
+# `claude <preserved-flags> --resume <id>` (or `... -r` if the id is unavailable),
+# so a restore reattaches each pane to its own Claude Code session.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=registry.sh
+source "$here/registry.sh"
+
+res_dir="$(tmux show-options -gv @resurrect-dir 2>/dev/null || true)"
+# Fallback mirrors tmux-resurrect's own default; Task 1 confirms the live dir.
+res_dir="${res_dir:-$HOME/.tmux/resurrect}"
+save="$res_dir/last"
+[ -f "$save" ] || exit 0
+real="$(readlink "$save" 2>/dev/null || true)"; real="${real:-$save}"
+case "$real" in /*) ;; *) real="$res_dir/$real" ;; esac
+
+# Live (session|window|pane_index) -> pane_id map.
+declare -A paneid=()
+while IFS=$'\t' read -r s w p id; do
+    paneid["$s|$w|$p"]="$id"
+done < <(tmux list-panes -a -F '#{session_name}	#{window_index}	#{pane_index}	#{pane_id}')
+
+projects="$HOME/.claude/projects"
+
+# Given the original full command + pane_id, produce the restore command.
+rewrite_cmd() {
+    local cmd="$1" pane_id="$2" flags sid
+    # Strip any existing resume/continue flags; keep the rest (e.g. --dangerously-skip-permissions).
+    flags="$(printf '%s' "$cmd" \
+        | sed -E 's/(^| )(-r|--resume([= ][^ ]+)?|-c|--continue)( |$)/ /g; s/  +/ /g; s/ +$//')"
+    sid="$(tcr_session_id "$pane_id")"
+    if [ -n "$sid" ] && compgen -G "$projects/*/$sid.jsonl" > /dev/null; then
+        printf '%s --resume %s' "$flags" "$sid"
+    else
+        printf '%s -r' "$flags"
+    fi
+}
+
+# --- Phase 1: rewrite each claude pane's restore command in the save file ---
+tmp="$(mktemp)"
+while IFS= read -r line || [ -n "$line" ]; do
+    if [ "${line%%$'\t'*}" = "pane" ]; then
+        IFS=$'\t' read -r -a f <<< "$line"
+        last=$(( ${#f[@]} - 1 ))
+        cmd="${f[$last]#:}"   # trailing field = the full command resurrect replays
+        # Anchor on the COMMAND field, not the whole line: a pane whose cwd merely
+        # contains "claude" must not be misclassified as a claude pane.
+        if [[ "$cmd" == "claude" || "$cmd" == claude\ * ]]; then
+            s="${f[1]}"; w="${f[2]}"; pidx="${f[5]}"
+            pane_id="${paneid["$s|$w|$pidx"]:-}"
+            if [ -n "$pane_id" ]; then
+                f[$last]=":$(rewrite_cmd "$cmd" "$pane_id")"
+                line="$(printf '%s\t' "${f[@]}")"; line="${line%$'\t'}"
+            fi
+        fi
+    fi
+    printf '%s\n' "$line"
+done < "$real" > "$tmp"
+mv "$tmp" "$real"
+
+# --- Phase 2: prune registry entries for panes that no longer exist ---
+# Guard: never call tcr_prune with zero live panes (that would wipe the registry).
+mapfile -t live < <(tmux list-panes -a -F '#{pane_id}')
+if [ "${#live[@]}" -gt 0 ]; then
+    tcr_prune "${live[@]}"
+fi

--- a/tmux-claude-resume/resurrect-inject-claude-resume.sh
+++ b/tmux-claude-resume/resurrect-inject-claude-resume.sh
@@ -49,14 +49,14 @@ while IFS= read -r line || [ -n "$line" ]; do
     if [ "${line%%$'\t'*}" = "pane" ]; then
         IFS=$'\t' read -r -a f <<< "$line"
         last=$(( ${#f[@]} - 1 ))
-        cmd="${f[$last]#:}"   # trailing field = the full command resurrect replays
+        cmd="${f[last]#:}"   # trailing field = the full command resurrect replays
         # Anchor on the COMMAND field, not the whole line: a pane whose cwd merely
         # contains "claude" must not be misclassified as a claude pane.
         if [[ "$cmd" == "claude" || "$cmd" == claude\ * ]]; then
             s="${f[1]}"; w="${f[2]}"; pidx="${f[5]}"
             pane_id="${paneid["$s|$w|$pidx"]:-}"
             if [ -n "$pane_id" ]; then
-                f[$last]=":$(rewrite_cmd "$cmd" "$pane_id")"
+                f[last]=":$(rewrite_cmd "$cmd" "$pane_id")"
                 line="$(printf '%s\t' "${f[@]}")"; line="${line%$'\t'}"
             fi
         fi

--- a/tmux-claude-resume/resurrect-inject-claude-resume.sh
+++ b/tmux-claude-resume/resurrect-inject-claude-resume.sh
@@ -27,10 +27,19 @@ projects="$HOME/.claude/projects"
 
 # Given the original full command + pane_id, produce the restore command.
 rewrite_cmd() {
-    local cmd="$1" pane_id="$2" flags sid
+    local cmd="$1" pane_id="$2" flags sid prev
     # Strip any existing resume/continue flags; keep the rest (e.g. --dangerously-skip-permissions).
-    flags="$(printf '%s' "$cmd" \
-        | sed -E 's/(^| )(-r|--resume([= ][^ ]+)?|-c|--continue)( |$)/ /g; s/  +/ /g; s/ +$//')"
+    # Pad with spaces and LOOP until stable so two ADJACENT resume-family flags are both removed —
+    # a single pass consumes the shared separator and would leave the second flag behind (e.g.
+    # `--resume x -c` -> `-c`), contradicting the appended id. (A bash loop, not sed's `:a;ta`,
+    # because BSD/macOS sed doesn't accept the label/branch form on one line.)
+    flags=" $cmd "
+    while :; do
+        prev="$flags"
+        flags="$(printf '%s' "$flags" | sed -E 's/ (-r|--resume([= ][^ ]+)?|-c|--continue) / /g')"
+        [ "$flags" = "$prev" ] && break
+    done
+    flags="$(printf '%s' "$flags" | sed -E 's/^ +//; s/ +$//; s/  +/ /g')"
     # Collapse repeated identical tokens, keeping first occurrence. Claude's launcher re-adds
     # --dangerously-skip-permissions on every launch, so without this it would accumulate
     # unbounded across reboot/restore cycles.
@@ -45,6 +54,7 @@ rewrite_cmd() {
 
 # --- Phase 1: rewrite each claude pane's restore command in the save file ---
 tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT   # don't leak the temp file if interrupted mid-rewrite
 while IFS= read -r line || [ -n "$line" ]; do
     if [ "${line%%$'\t'*}" = "pane" ]; then
         IFS=$'\t' read -r -a f <<< "$line"

--- a/tmux-claude-resume/resurrect-inject-claude-resume.sh
+++ b/tmux-claude-resume/resurrect-inject-claude-resume.sh
@@ -31,6 +31,10 @@ rewrite_cmd() {
     # Strip any existing resume/continue flags; keep the rest (e.g. --dangerously-skip-permissions).
     flags="$(printf '%s' "$cmd" \
         | sed -E 's/(^| )(-r|--resume([= ][^ ]+)?|-c|--continue)( |$)/ /g; s/  +/ /g; s/ +$//')"
+    # Collapse repeated identical tokens, keeping first occurrence. Claude's launcher re-adds
+    # --dangerously-skip-permissions on every launch, so without this it would accumulate
+    # unbounded across reboot/restore cycles.
+    flags="$(printf '%s' "$flags" | awk '{for(i=1;i<=NF;i++) if(!seen[$i]++) printf "%s%s",(n++?OFS:""),$i}')"
     sid="$(tcr_session_id "$pane_id")"
     if [ -n "$sid" ] && compgen -G "$projects/*/$sid.jsonl" > /dev/null; then
         printf '%s --resume %s' "$flags" "$sid"

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -55,6 +55,10 @@ set -g @plugin 'seebi/tmux-colors-solarized'
 # --- session persistence (resurrect + continuum) ---
 set -g @continuum-restore 'on'                 # auto-restore sessions when tmux next starts
 set -g @resurrect-capture-pane-contents 'on'   # snapshot scrollback so the pre-reboot screen is readable
+# relaunch each claude pane on restore; the post-save hook rewrites the saved
+# command to `claude --resume <id>` per pane (see tmux-claude-resume/).
+set -g @resurrect-processes '~claude'
+set -g @resurrect-hook-post-save-all 'bash ~/.config/tmux-claude-resume/resurrect-inject-claude-resume.sh'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '$HOME/.tmux/plugins/tpm/tpm'

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -52,6 +52,10 @@ set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'tmux-plugins/tmux-prefix-highlight'
 set -g @plugin 'seebi/tmux-colors-solarized'
 
+# --- session persistence (resurrect + continuum) ---
+set -g @continuum-restore 'on'                 # auto-restore sessions when tmux next starts
+set -g @resurrect-capture-pane-contents 'on'   # snapshot scrollback so the pre-reboot screen is readable
+
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '$HOME/.tmux/plugins/tpm/tpm'
 

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -58,6 +58,6 @@ run '$HOME/.tmux/plugins/tpm/tpm'
 # Disable this for iterm2
 setw -g aggressive-resize off
 
-if '[ "$ITERM_PROFILE" = "dark" ]' 'source $HOME/.tmux/plugins/tmux-colors-solarized/tmuxcolors-dark.conf' ''
-if '[ "$ITERM_PROFILE" = "light" ]' 'source $HOME/.tmux/plugins/tmux-colors-solarized/tmuxcolors-light.conf' ''
+if '[ "$ITERM_PROFILE" = "dark" ]' 'source -q $HOME/.tmux/plugins/tmux-colors-solarized/tmuxcolors-dark.conf' ''
+if '[ "$ITERM_PROFILE" = "light" ]' 'source -q $HOME/.tmux/plugins/tmux-colors-solarized/tmuxcolors-light.conf' ''
 set -g @colors-solarized "$ITERM_PROFILE"


### PR DESCRIPTION
## Summary

Four related bodies of work, built spec → plan → validate → subagent-driven execution, then polished via parallel code review (pr-review-toolkit + superpowers).

### 1. Tmux plugin bootstrap (fixes a startup error)
TPM plugins were declared but never installed, so `~/.tmux/plugins` didn't exist and `tmux.conf` errored on startup sourcing the missing Solarized colorscheme.
- `install.sh`: idempotent TPM clone into `~/.tmux/plugins/tpm`
- `tmux.conf`: `source -q` for the Solarized files (missing plugin no longer errors)

### 2. Tmux session persistence across reboot
- `@continuum-restore 'on'` — sessions auto-restore on next tmux start
- `@resurrect-capture-pane-contents 'on'` — scrollback restored too
- Windows, panes, layout, and per-pane working directories survive a reboot

### 3. Per-pane Claude Code resume (`tmux-claude-resume/`)
The headline feature. tmux-resurrect only knows the command that *launched* a pane, and `claude --continue` collides when two panes share a directory. This makes each restored pane resume **its own** conversation by session ID:
- **`registry.sh`** — single-owner pane→session registry (record/lookup/prune)
- **`record-tmux-session.sh`** — Claude `SessionStart` hook recording `pane → session_id` (`$CLAUDE_CODE_SESSION_ID` + `$TMUX_PANE`)
- **`resurrect-inject-claude-resume.sh`** — resurrect `@resurrect-hook-post-save-all` that rewrites each claude pane's restore command to `claude <your-flags> --resume <id>` (or `-r` if the session is gone), preserving flags like `--dangerously-skip-permissions`
- **`install-hook.sh`** — idempotent installer for the global `~/.claude/settings.json` (validates JSON; never touches a repo-local `.claude/settings.json`)
- Deploys to `~/.config/tmux-claude-resume/` via `dotfiles.yaml`. See `tmux-claude-resume/README.md`.

### 4. Development infrastructure & CI fixes
- Claude Code GitHub workflows (`claude-on-mention`, `claude-pr-review`), `docs/ENGINEERING_STANDARDS.md`, `CONTRIBUTING.md`
- Fixed shellcheck `SC2004` and a pre-existing `DOTFILES_DIR` test-resolution bug (the existing suites resolved it *above* the repo root, so their file globs never matched)

## Tests & quality
- **40 bats tests** across 6 suites (registry, capture hook, injection hook, installer, persistence, baseline) — all green; pytest 12/12; shellcheck clean
- Two tmux-resurrect assumptions verified by **live spikes** before building (post-save hook fires; restore replays the rewritten command field)
- **Parallel code review** (pr-review-toolkit + superpowers): both verified the save-file field indices against real tmux-resurrect source. Findings addressed in-PR: adjacent resume-family flag stripping (looped, BSD-sed-safe), temp-file cleanup trap, corrupt-`settings.json` guard, flag-accumulation dedup.

## Test plan

**Done (executed + evidenced):**
- [x] CI green on macOS + Ubuntu — shellcheck, pytest, validation, benchmark
- [x] 40/40 bats tests pass locally; all `tmux-claude-resume/*.sh` shellcheck-clean
- [x] **End-to-end on an isolated tmux socket** (Task 7, see PR comment): real `claude` session → `SessionStart` hook recorded `pane → session_id` → resurrect save → injection rewrote to `claude … --resume <id>` → kill (test socket) → restore → pane relaunched with `--resume <id>`, reattaching to its exact session
- [x] Same-cwd collision case proven (two panes in one dir → two distinct sessions recorded)
- [x] Idempotent installer (run twice → one hook; corrupt JSON → clear error, file untouched)
- [x] Adjacent-flag strip + duplicate-flag dedup verified across adversarial inputs

**Manual (yours to exercise):**
- [ ] [manual] Activate in a real long-lived session (`tmux source-file ~/.tmux.conf`) and confirm recovery after an **actual machine reboot** (the one surface a sandboxed test can't fully reproduce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)