### PR TITLE
chore(shell,git): portable shell-integration & gh credential paths

### DIFF
--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -148,3 +148,9 @@ fi
 # Allow interactive commands to fail without triggering ERR trap
 set +e
 trap - ERR
+
+# add Pulumi to the PATH
+[ -d "$HOME/.pulumi/bin" ] && export PATH="$PATH:$HOME/.pulumi/bin"
+
+test -e "${HOME}/.iterm2_shell_integration.bash" && source "${HOME}/.iterm2_shell_integration.bash"
+

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -1,6 +1,6 @@
 [user]
-        name = Sam Stavinoha
-        email = hi@stav.xyz
+	name = samuel
+	email = hi@stav.xyz
 [alias]
         stashes = stash list
         branches = branch -a -v --color
@@ -26,13 +26,22 @@
         username = samstav
 [push]
         default = current
-
-[url "ssh://git@github.com/"]
-	insteadOf = https://github.com/
-
 [core]
         excludesfile = ~/.gitignore_global
 [pull]
 	rebase = true
 [init]
 	defaultBranch = main
+[credential "https://github.com"]
+	helper = 
+	helper = !gh auth git-credential
+[credential "https://gist.github.com"]
+	helper = 
+	helper = !gh auth git-credential
+[url "ssh://git@github.com/"]
+	insteadof = https://github.com/
+[filter "lfs"]
+	required = true
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
+	process = git-lfs filter-process


### PR DESCRIPTION
## Summary

Cleans up two machine-specific hardcoded paths that had leaked into the tracked shell/git config (so they work on any machine, not just this one):

- **`bash/bash_profile`** — Pulumi is added to `PATH` via `$HOME/.pulumi/bin` (guarded on the dir existing) instead of a hardcoded `/Users/stavxyz/...`; iTerm2 shell integration is sourced if present (already `$HOME`-guarded).
- **`git/gitconfig`** — the GitHub credential helper now uses `!gh auth git-credential` (resolved via `PATH`) instead of a hardcoded `/opt/homebrew/bin/gh`, so it works on Intel macOS and Linux too. Also captures the standard `git-lfs` filter config and the current `user.name`.

## Notes
- These were tool/installer side-effects (Pulumi installer, `gh auth setup-git`, `git lfs install`) that ended up in the symlinked dotfiles; this commit makes them portable.
- **Out of scope (deliberately):** three untracked `.github/workflows/` files (`python-quality.yml`, `shellcheck.yml`, `requirements-quality.txt`) are left untracked — they need a dedicated audit/overhaul (e.g. `python-quality.yml` currently fails against the repo's Python: `ruff`/`format` issues + a `raw_input` Python-2 bug in `dot.py`; `shellcheck.yml` overlaps `test.yml`'s broader shellcheck).

## Test plan
- [x] `bash_profile` change is a guarded PATH append — no behavior change when `~/.pulumi/bin` is absent
- [x] `gitconfig` parses cleanly (`git config -l` works); credential helper resolves `gh` via PATH
- [ ] [manual] confirm `gh`-backed git auth still works on a fresh shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)