### PR TITLE
ci: consolidate quality gates into test.yml; fix Python lint/type

### DIFF
--- a/.github/workflows/requirements-quality.txt
+++ b/.github/workflows/requirements-quality.txt
@@ -1,0 +1,7 @@
+# Python code quality tools
+# Pin versions for reproducible builds
+
+ruff==0.8.4
+mypy==1.13.0
+pytest==8.3.4
+pytest-cov==6.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,13 +53,22 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov
+          pip install -r .github/workflows/requirements-quality.txt
 
       - name: Run ShellCheck linting
         run: |
           # Check all shell scripts and bash config files
           find . -type f \( -name "*.sh" -o -name "bash_profile" -o -name "bashrc" -o -name "bash_aliases" \) \
             -exec shellcheck {} +
+
+      - name: Lint with ruff
+        run: ruff check .
+
+      - name: Format check with ruff
+        run: ruff format --check .
+
+      - name: Type check with mypy
+        run: mypy . --ignore-missing-imports
 
       - name: Run Python tests
         id: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,11 +55,39 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r .github/workflows/requirements-quality.txt
 
-      - name: Run ShellCheck linting
+      - name: ShellCheck (lint + forbid blanket disables)
         run: |
-          # Check all shell scripts and bash config files
-          find . -type f \( -name "*.sh" -o -name "bash_profile" -o -name "bashrc" -o -name "bash_aliases" \) \
-            -exec shellcheck {} +
+          # Lint every TRACKED shell script, detected by first-line shebang so extensionless
+          # scripts (git hooks, bin/ tools) are covered too — not just *.sh. Scanning git-tracked
+          # files matches what CI checks out and auto-skips gitignored/vendored content. Exclude
+          # the vendored completions dir, bats tests (bats syntax shellcheck can't parse), and md.
+          scripts=$(git ls-files -z | while IFS= read -r -d '' f; do
+            case "$f" in autocomplete/*|*.bats|*.md) continue;; esac
+            [ -f "$f" ] || continue
+            if head -n1 "$f" | grep -qE '^#!.*(bash|/sh|env sh)'; then printf '%s\n' "$f"; fi
+          done | sort -u)
+          if [ -z "$scripts" ]; then echo "No shell scripts found"; exit 0; fi
+          echo "Shell scripts under shellcheck:"; echo "$scripts" | sed 's/^/  /'
+
+          # Policy: no blanket (file-level) disables. A `# shellcheck disable=` must annotate
+          # the next line of code; one followed by a blank line or another comment is a global
+          # suppression and is forbidden — use a targeted per-line disable instead.
+          policy_fail=0
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            awk -v file="$f" '
+              prev==1 { if ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*#/) {
+                          printf "::error file=%s,line=%d::blanket \"# shellcheck disable\" is forbidden — put a per-line disable directly above the offending line\n", file, NR-1; bad=1 }
+                        prev=0 }
+              /^[[:space:]]*#[[:space:]]*shellcheck[[:space:]]+disable=/ { prev=1 }
+              END { exit bad }
+            ' "$f" || policy_fail=1
+          done <<< "$scripts"
+
+          # Lint every detected script (null-delimited to be filename-safe).
+          echo "$scripts" | tr '\n' '\0' | xargs -0 shellcheck
+
+          [ "$policy_fail" -eq 0 ]
 
       - name: Lint with ruff
         run: ruff check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,10 @@ jobs:
           # scripts (git hooks, bin/ tools) are covered too — not just *.sh. Scanning git-tracked
           # files matches what CI checks out and auto-skips gitignored/vendored content. Exclude
           # the vendored completions dir, bats tests (bats syntax shellcheck can't parse), and md.
+          # (uses [[ ]] not case: bash 3.2 — the macOS runner shell — misparses case-pattern
+          # ")" as the closing paren of $(...), so case here is a syntax error there.)
           scripts=$(git ls-files -z | while IFS= read -r -d '' f; do
-            case "$f" in autocomplete/*|*.bats|*.md) continue;; esac
+            if [[ "$f" == autocomplete/* || "$f" == *.bats || "$f" == *.md ]]; then continue; fi
             [ -f "$f" ] || continue
             if head -n1 "$f" | grep -qE '^#!.*(bash|/sh|env sh)'; then printf '%s\n' "$f"; fi
           done | sort -u)

--- a/docs/superpowers/plans/2026-06-15-ci-consolidation.md
+++ b/docs/superpowers/plans/2026-06-15-ci-consolidation.md
@@ -1,3 +1,17 @@
+---
+validated:
+  sha: f072b4e5efd6fbf90b5ee724ed5b5882dcfc522b
+  date: 2026-06-18T00:11:34Z
+  reviewers: [fact-check, solid-hygiene]
+  findings:
+    critical: 0
+    important: 0
+    medium: 0
+    low: 2
+    nitpick: 1
+  net_negative_remaining: 0
+---
+
 # CI Consolidation + Python Lint/Type Fixes — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
@@ -163,7 +177,7 @@ Expected: `test.yml: valid YAML`; `all quality gates green`.
 Run:
 ```bash
 ls .github/workflows/                       # expect: requirements-quality.txt  test.yml
-grep -E 'ruff check|ruff format --check|mypy . --ignore-missing-imports|requirements-quality.txt' .github/workflows/test.yml
+grep -E 'ruff check|ruff format --check|mypy \. --ignore-missing-imports|requirements-quality\.txt' .github/workflows/test.yml
 ```
 Expected: only `test.yml` + `requirements-quality.txt` present; all four grep patterns found.
 
@@ -174,6 +188,15 @@ git add .github/workflows/test.yml .github/workflows/requirements-quality.txt
 git commit -m "ci: consolidate ruff/format/mypy into test.yml; drop redundant workflows"
 ```
 
+> **Design note (2026-06-17):** Deleting `shellcheck.yml` removes a gate that `test.yml` does
+> NOT replicate: a "global ShellCheck disables FORBIDDEN" policy step that fails CI if a script
+> carries a top-of-file `# shellcheck disable=` directive (forcing per-line disables instead),
+> plus an advisory script-executability check. The shellcheck *linting* coverage is fully
+> preserved (test.yml's `find .` scope is a superset of `.claude/**`), so only that policy gate
+> is retired. This is an intentional, documented consequence of the blessed spec's deletion —
+> not an oversight. If the no-blanket-disable policy is worth keeping, fold its one `grep`-based
+> guard into `test.yml`'s ShellCheck step as a follow-up (out of scope for this plan).
+
 ---
 
 ## Notes for the implementer
@@ -183,3 +206,4 @@ git commit -m "ci: consolidate ruff/format/mypy into test.yml; drop redundant wo
 - **`requirements-quality.txt` already exists untracked** with the right pins; Task 2 just tracks it. Do not rewrite it.
 - **Keep commits attribution-free** (Global Constraints).
 - The full `bats tests/` suite should also stay green (it's unaffected), but `test.yml` only runs `test-validate.bats` + `test-benchmark.bats`.
+- **Local `ruff`/`mypy` may resolve to pyenv shims** (newer versions) rather than the pinned `0.8.4`/`1.13.0`; only CI (`pip install -r requirements-quality.txt`) guarantees the pins. The baselines match across versions here, but if you want the local dry-runs to exactly mirror CI, `pip install -r .github/workflows/requirements-quality.txt` into the venv first.

--- a/docs/superpowers/plans/2026-06-15-ci-consolidation.md
+++ b/docs/superpowers/plans/2026-06-15-ci-consolidation.md
@@ -1,0 +1,185 @@
+# CI Consolidation + Python Lint/Type Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the repo's Python pass `ruff`/`ruff format`/`mypy`, then fold those gates into the single `test.yml` workflow and delete the two redundant untracked workflows.
+
+**Architecture:** Two ordered tasks. Task 1 cleans the Python (so the gates are green); Task 2 adds the gates to `test.yml` and removes the duplicates. Task 1 MUST land before Task 2 — adding the CI gates while the Python is dirty would make CI red.
+
+**Tech Stack:** GitHub Actions (`test.yml`, macOS + Ubuntu matrix), ruff 0.8.4, mypy 1.13.0, pytest, bats, shellcheck.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-ci-consolidation-design.md` (blessed; one accepted net-negative — `mypy .` is intentionally unscoped, verified to check only the 3 first-party files).
+
+## Global Constraints
+
+- **Python 2.7 compatibility retained** — do NOT remove the `raw_input` shim; do NOT introduce Python-3-only syntax. (Spec: Py2 classifiers + `requires-python = ">=2.7"` stay.)
+- **No `[tool.ruff]` / `[tool.mypy]` config** added to `pyproject.toml` — tool behavior stays in pinned versions + CLI invocations.
+- **Tool versions pinned** in `.github/workflows/requirements-quality.txt`: `ruff==0.8.4`, `mypy==1.13.0`, `pytest==8.3.4`, `pytest-cov==6.0.0`.
+- **`mypy . --ignore-missing-imports`** is used verbatim (unscoped `.`) — accepted; it checks only `dot.py`/`tests/` because `venv/` is not a package.
+- **No Claude attribution in commits** (no `Co-Authored-By: Claude`, no `🤖 Generated with` footers).
+- **Branch:** `chore/ci-consolidation` (already created, off `main`). Commit there; do not push to `main`.
+
+---
+
+### Task 1: Make the repo Python pass ruff / format / mypy (Py2.7-safe)
+
+**Files:**
+- Modify: `tests/conftest.py` (remove 2 unused imports)
+- Modify: `tests/test_dotfiles.py` (remove 2 unused imports)
+- Modify: `dot.py` (silence the one mypy error on the Py2 shim)
+- Reformat: all three of the above via `ruff format`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a Python tree where `ruff check .`, `ruff format --check .`, and `mypy . --ignore-missing-imports` all exit 0, and `pytest tests/` still passes. Task 2 relies on these gates being green.
+
+- [ ] **Step 1: Confirm the gates currently fail (the "red" state)**
+
+Run (activate the venv first):
+```bash
+source venv/bin/activate
+ruff check .            # expect: 4 errors (F401 unused imports)
+ruff format --check .   # expect: "3 files would be reformatted" (dot.py, conftest.py, test_dotfiles.py)
+mypy . --ignore-missing-imports   # expect: 1 error — dot.py:20 Name "raw_input" is not defined
+```
+Expected: all three report the issues above. This is the baseline to fix.
+
+- [ ] **Step 2: Remove the unused imports**
+
+In `tests/conftest.py`, delete these two lines (currently lines 7–8):
+```python
+import tempfile
+import shutil
+```
+
+In `tests/test_dotfiles.py`, delete the unused `import tempfile` (line 8) and `import pytest` (line 9). Keep `import os` / `import sys`. (ruff F401 confirms `pytest` is unreferenced — Step 5's pytest run re-verifies nothing broke.)
+
+- [ ] **Step 3: Silence the mypy error on the Python-2 shim**
+
+In `dot.py`, the shim is:
+```python
+try:
+    input = raw_input  # Python 2
+except NameError:
+    pass  # Python 3
+```
+Change the `input = raw_input` line to add a targeted ignore (keeps the shim, satisfies mypy):
+```python
+    input = raw_input  # type: ignore[name-defined]  # Python 2
+```
+
+- [ ] **Step 4: Apply formatting**
+
+Run: `ruff format .`
+Expected: `3 files reformatted` (dot.py, tests/conftest.py, tests/test_dotfiles.py). This is a deterministic Black-style reformat (whitespace/quotes); it introduces no Python-3-only syntax, so Py2.7 compatibility is preserved.
+
+- [ ] **Step 5: Verify all gates are green + tests still pass**
+
+Run:
+```bash
+ruff check .                        # expect: "All checks passed!"
+ruff format --check .               # expect: no files would be reformatted
+mypy . --ignore-missing-imports     # expect: "Success: no issues found in 3 source files" (or no errors)
+pytest tests/ -v                    # expect: all tests pass (confirms import removal was safe)
+```
+Expected: ruff/format/mypy clean; pytest green. If `pytest` import removal broke a test (it shouldn't — F401 means unreferenced), restore only the genuinely-used import and re-run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dot.py tests/conftest.py tests/test_dotfiles.py
+git commit -m "fix(python): drop unused imports, format, and silence Py2 raw_input shim for mypy"
+```
+
+---
+
+### Task 2: Consolidate quality gates into test.yml; delete redundant workflows
+
+**Files:**
+- Modify: `.github/workflows/test.yml` (install from requirements file; add ruff/format/mypy steps)
+- Add (commit the currently-untracked file): `.github/workflows/requirements-quality.txt`
+- Delete (currently untracked — remove from working tree): `.github/workflows/python-quality.yml`, `.github/workflows/shellcheck.yml`
+
+**Interfaces:**
+- Consumes: the green gates from Task 1 (ruff/format/mypy pass on the repo).
+- Produces: a single CI workflow that runs shellcheck → ruff check → ruff format check → mypy → pytest → validation bats → benchmark bats, on macOS + Ubuntu.
+
+- [ ] **Step 1: Point the dependency install at the pinned requirements file**
+
+In `.github/workflows/test.yml`, replace the existing step:
+```yaml
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov
+```
+with:
+```yaml
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r .github/workflows/requirements-quality.txt
+```
+(`requirements-quality.txt` pins `ruff`, `mypy`, `pytest`, `pytest-cov` — so this one install covers the new gates and the existing pytest step.)
+
+- [ ] **Step 2: Add the three quality steps after the ShellCheck step**
+
+In `.github/workflows/test.yml`, immediately after the existing `Run ShellCheck linting` step and before `Run Python tests`, insert:
+```yaml
+      - name: Lint with ruff
+        run: ruff check .
+
+      - name: Format check with ruff
+        run: ruff format --check .
+
+      - name: Type check with mypy
+        run: mypy . --ignore-missing-imports
+```
+These have no `if:` guard, so they run on **both** matrix legs (macOS + Ubuntu) — per the spec's accepted simplicity tradeoff.
+
+- [ ] **Step 3: Track the requirements file; delete the redundant workflows**
+
+Run (the two workflows are untracked, so a plain `rm` removes them — no `git rm` needed):
+```bash
+rm -f .github/workflows/python-quality.yml .github/workflows/shellcheck.yml
+git add .github/workflows/requirements-quality.txt .github/workflows/test.yml
+git status --short .github/workflows/
+```
+Expected: `test.yml` modified (`M`), `requirements-quality.txt` added (`A`), and `python-quality.yml` / `shellcheck.yml` gone from the tree (no longer listed as `??`).
+
+- [ ] **Step 4: Validate the workflow YAML + dry-run the gate commands locally**
+
+Run:
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/test.yml')); print('test.yml: valid YAML')"
+# the exact commands CI will now run (must be clean after Task 1):
+source venv/bin/activate
+ruff check . && ruff format --check . && mypy . --ignore-missing-imports && echo "all quality gates green"
+```
+Expected: `test.yml: valid YAML`; `all quality gates green`.
+
+- [ ] **Step 5: Confirm only test.yml remains and it contains the new steps**
+
+Run:
+```bash
+ls .github/workflows/                       # expect: requirements-quality.txt  test.yml
+grep -E 'ruff check|ruff format --check|mypy . --ignore-missing-imports|requirements-quality.txt' .github/workflows/test.yml
+```
+Expected: only `test.yml` + `requirements-quality.txt` present; all four grep patterns found.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/test.yml .github/workflows/requirements-quality.txt
+git commit -m "ci: consolidate ruff/format/mypy into test.yml; drop redundant workflows"
+```
+
+---
+
+## Notes for the implementer
+
+- **Order is load-bearing:** Task 1 (clean Python) before Task 2 (enforce gates). Running Task 2 first would make CI red.
+- **The real proof is CI:** after both tasks, push the branch and confirm `test.yml` is green on macOS + Ubuntu (shellcheck → ruff → format → mypy → pytest → bats). Local dry-runs in the steps above are the pre-push check.
+- **`requirements-quality.txt` already exists untracked** with the right pins; Task 2 just tracks it. Do not rewrite it.
+- **Keep commits attribution-free** (Global Constraints).
+- The full `bats tests/` suite should also stay green (it's unaffected), but `test.yml` only runs `test-validate.bats` + `test-benchmark.bats`.

--- a/docs/superpowers/specs/2026-06-15-ci-consolidation-design.md
+++ b/docs/superpowers/specs/2026-06-15-ci-consolidation-design.md
@@ -1,0 +1,85 @@
+# Design: CI consolidation + Python lint/type fixes
+
+**Date:** 2026-06-15
+**Status:** Approved
+**Branch:** chore/ci-consolidation
+
+## Goal
+
+One coherent CI workflow (`test.yml`) that lints, type-checks, and tests with zero
+redundancy, and a repo whose Python passes `ruff` / `ruff format` / `mypy` — while keeping
+the project's existing Python 2.7 support.
+
+## Background
+
+Three workflow files exist; two are untracked WIP and overlap the tracked `test.yml`:
+
+- **`test.yml`** (tracked, active CI) — on push/PR to `main`, macOS + Ubuntu matrix:
+  `find .`-based shellcheck, `pytest tests/`, `bats test-validate.bats`, `bats test-benchmark.bats`.
+- **`python-quality.yml`** (untracked) — `ruff check`, `ruff format --check`, `mypy`,
+  `pytest` + coverage on a 3.11/3.12 matrix. Its `pytest` **duplicates** `test.yml`.
+- **`shellcheck.yml`** (untracked) — shellcheck limited to `.claude/**`; **redundant** with
+  `test.yml`'s broader `find .` shellcheck.
+
+The repo's Python (only `dot.py`, `tests/conftest.py`, `tests/test_dotfiles.py`) currently
+fails the quality gates: 4 unused imports (ruff F401), 3 files need formatting, and `mypy`
+flags `raw_input` — the intentional Python-2 compatibility shim in `dot.py`. `pyproject.toml`
+declares `requires-python = ">=2.7"` with Py2 classifiers; Python 2 support is **retained**
+(operator decision).
+
+## Design
+
+### Python fixes (all Python-2.7-safe)
+
+1. `tests/conftest.py` — remove unused `import tempfile`, `import shutil`.
+2. `tests/test_dotfiles.py` — remove unused `import tempfile`, `import pytest`. Re-run the
+   suite afterward to confirm `pytest` was genuinely unreferenced (ruff F401 says so).
+3. `dot.py` — add `# type: ignore[name-defined]` to the `input = raw_input` line. Keeps the
+   Py2 shim; silences the sole mypy error.
+4. `ruff format` the three files (Black-style whitespace/quote normalization — introduces no
+   Python-3-only syntax, so Py2.7 compatibility is preserved).
+
+No `[tool.ruff]` / `[tool.mypy]` config is added — the workflow invocations (`ruff check .`,
+`ruff format --check .`, `mypy . --ignore-missing-imports`) plus tool defaults suffice.
+Py2 classifiers and `requires-python` are left untouched.
+
+### CI consolidation (single workflow: `test.yml`)
+
+1. In `test.yml`, install the quality tools from the existing `requirements-quality.txt`
+   (already pins `ruff==0.8.4`, `mypy==1.13.0`, `pytest==8.3.4`, `pytest-cov==6.0.0`) instead
+   of the current inline `pip install pytest pytest-cov`.
+2. Add three steps after the existing ShellCheck step, **on both matrix OSes** (macOS +
+   Ubuntu — results are OS-independent, so running on both is harmless and keeps the matrix
+   uniform):
+   - `ruff check .`
+   - `ruff format --check .`
+   - `mypy . --ignore-missing-imports`
+3. The existing `pytest`, validation, and benchmark steps stay.
+4. **Delete** `python-quality.yml` (pytest duplicates `test.yml`) and `shellcheck.yml`
+   (redundant with `test.yml`'s `find .` shellcheck). These are untracked, so deletion = `rm`.
+5. **Keep** `requirements-quality.txt` (now consumed by `test.yml`).
+
+### Result
+
+A single CI workflow runs: shellcheck → ruff check → ruff format check → mypy → pytest →
+validation bats → benchmark bats, on macOS + Ubuntu. No duplicated pytest, no redundant
+shellcheck.
+
+## Testing
+
+Locally, all green before pushing:
+- `ruff check .` → clean
+- `ruff format --check .` → clean
+- `mypy . --ignore-missing-imports` → clean
+- `pytest tests/ -v` → pass (confirms the import removals didn't break tests)
+- `bats tests/` → pass
+- `shellcheck` over the repo's shell scripts → clean
+Then confirm the consolidated `test.yml` is green on the PR (macOS + Ubuntu).
+
+## Scope / YAGNI
+
+- Python 2 support retained (no shim removal, no classifier/`requires-python` changes).
+- No new lint/type configuration in `pyproject.toml`.
+- No reformatting of non-Python files.
+- The CI workflow audit is limited to these three files; no changes to the bats suites or
+  the test harness beyond installing tools from `requirements-quality.txt`.

--- a/docs/superpowers/specs/2026-06-15-ci-consolidation-design.md
+++ b/docs/superpowers/specs/2026-06-15-ci-consolidation-design.md
@@ -1,3 +1,17 @@
+---
+validated:
+  sha: 42dd6ed3d9bb3c22402efc5dd2cb45b17655177c
+  date: 2026-06-17T21:26:10Z
+  reviewers: [fact-check, solid-hygiene]
+  findings:
+    critical: 0
+    important: 2
+    medium: 1
+    low: 1
+    nitpick: 0
+  net_negative_remaining: 1
+---
+
 # Design: CI consolidation + Python lint/type fixes
 
 **Date:** 2026-06-15
@@ -15,7 +29,7 @@ the project's existing Python 2.7 support.
 Three workflow files exist; two are untracked WIP and overlap the tracked `test.yml`:
 
 - **`test.yml`** (tracked, active CI) — on push/PR to `main`, macOS + Ubuntu matrix:
-  `find .`-based shellcheck, `pytest tests/`, `bats test-validate.bats`, `bats test-benchmark.bats`.
+  `find .`-based shellcheck, `pytest tests/`, `bats tests/test-validate.bats`, `bats tests/test-benchmark.bats`.
 - **`python-quality.yml`** (untracked) — `ruff check`, `ruff format --check`, `mypy`,
   `pytest` + coverage on a 3.11/3.12 matrix. Its `pytest` **duplicates** `test.yml`.
 - **`shellcheck.yml`** (untracked) — shellcheck limited to `.claude/**`; **redundant** with
@@ -64,6 +78,24 @@ Py2 classifiers and `requires-python` are left untouched.
 A single CI workflow runs: shellcheck → ruff check → ruff format check → mypy → pytest →
 validation bats → benchmark bats, on macOS + Ubuntu. No duplicated pytest, no redundant
 shellcheck.
+
+> **Accepted net-negative tradeoff (2026-06-17):** The design hard-codes `mypy .` (with no
+> `[tool.mypy]` scoping) into the canonical `test.yml`, which a reviewer flagged as relying on
+> mypy's package-walk defaults rather than an explicit scope. Accepted with explicit operator
+> approval: verified that `mypy . --ignore-missing-imports` checks only the 3 first-party files
+> ("checked 3 source files") because `venv/` is not a Python package and is therefore not
+> recursed; the minimal, config-free scope is intentional for a 3-file Python surface.
+
+> **Design note (2026-06-17):** Tool configuration is deliberately kept out of `pyproject.toml`
+> (no `[tool.ruff]`/`[tool.mypy]`); behavior lives in the pinned tool versions
+> (`requirements-quality.txt`) plus the CLI invocations in `test.yml`. If a third Python file,
+> a per-rule ignore, or a `target-version` is ever needed, `pyproject.toml` is the place to
+> centralize it — the consolidation doesn't preclude that, it just doesn't pre-build it (YAGNI).
+
+> **Design note (2026-06-17):** Running ruff/format/mypy on both matrix legs (macOS + Ubuntu)
+> duplicates OS-independent work; this is an accepted simplicity tradeoff (uniform, branch-free
+> matrix) for a tiny repo. If CI minutes ever matter, factor the OS-independent quality checks
+> into a single-runner job.
 
 ## Testing
 

--- a/dot.py
+++ b/dot.py
@@ -17,33 +17,37 @@ import sys
 
 # Python 2/3 compatibility
 try:
-    input = raw_input  # Python 2
+    input = raw_input  # type: ignore[name-defined]  # Python 2
 except NameError:
     pass  # Python 3
 
-VERSION = '1.0.0'
-DEFAULT_CONFIG = 'dotfiles.json'
+VERSION = "1.0.0"
+DEFAULT_CONFIG = "dotfiles.json"
 DEBUG = False
+
 
 # ANSI color codes
 class Colors:
-    RED = '\033[91m'
-    GREEN = '\033[92m'
-    YELLOW = '\033[93m'
-    BLUE = '\033[94m'
-    BOLD = '\033[1m'
-    RESET = '\033[0m'
+    RED = "\033[91m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    BLUE = "\033[94m"
+    BOLD = "\033[1m"
+    RESET = "\033[0m"
 
 
 def _use_color():
     """Check if we should use color output."""
-    return sys.stdout.isatty() and os.getenv('NO_COLOR') is None
+    return sys.stdout.isatty() and os.getenv("NO_COLOR") is None
 
 
 def print_error(msg, abort=True):
     """Print error message to stderr and optionally exit."""
     if _use_color():
-        print("{}{}{}{}".format(Colors.RED, Colors.BOLD, msg, Colors.RESET), file=sys.stderr)
+        print(
+            "{}{}{}{}".format(Colors.RED, Colors.BOLD, msg, Colors.RESET),
+            file=sys.stderr,
+        )
     else:
         print("ERROR: {}".format(msg), file=sys.stderr)
     if abort:
@@ -74,14 +78,14 @@ def print_info(msg):
 def confirm(prompt, default=False):
     """Ask user for yes/no confirmation."""
     prompt_str = "{} [Y/n] ".format(prompt) if default else "{} [y/N] ".format(prompt)
-    valid_yes = {'y', 'yes', ''} if default else {'y', 'yes'}
+    valid_yes = {"y", "yes", ""} if default else {"y", "yes"}
 
     while True:
         try:
             choice = input(prompt_str).lower()
             if choice in valid_yes:
                 return True
-            elif choice in {'n', 'no', ''} if not default else {'n', 'no'}:
+            elif choice in {"n", "no", ""} if not default else {"n", "no"}:
                 return False
             else:
                 print("Please respond with 'yes' or 'no'")
@@ -102,34 +106,34 @@ def _normalize_path(path, globbing=False, resolve=True):
     ]
     if globbing:
         funcs.append(glob.glob)
-    return functools.reduce(
-        lambda x, y: y(x), funcs, path
-    )
+    return functools.reduce(lambda x, y: y(x), funcs, path)
 
 
 def _filetype(path):
     path = _normalize_path(path, resolve=False)
-    return filter(None,
+    return filter(
+        None,
         [
-            os.path.islink(path) and 'link',
-            os.path.isdir(path) and 'dir',
-            os.path.isfile(path) and 'file',
-            os.path.ismount(path) and 'mount',
-        ]
+            os.path.islink(path) and "link",
+            os.path.isdir(path) and "dir",
+            os.path.isfile(path) and "file",
+            os.path.ismount(path) and "mount",
+        ],
     )
 
 
 def load_config(config_path):
     """Load config from JSON file."""
     try:
-        with open(config_path, 'r') as f:
+        with open(config_path, "r") as f:
             return json.load(f)
     except (IOError, ValueError) as e:
-        print_error('Failed to load config file {}: {}'.format(config_path, e))
+        print_error("Failed to load config file {}: {}".format(config_path, e))
         return {}
 
 
 # what happens if --source uses a glob?
+
 
 def cmd_link(args, config):
     """Create symlinks."""
@@ -139,12 +143,12 @@ def cmd_link(args, config):
     source = args.source
     target = args.target
 
-    links = (config.get('links', {}) or {}) if use_config else {}
+    links = (config.get("links", {}) or {}) if use_config else {}
     if target or source:
         links[target] = source
     links = _resolve_all_links(links, config)
     if DEBUG:
-        print_info('Symlinks to create:')
+        print_info("Symlinks to create:")
         print_info(json.dumps(links, indent=2, sort_keys=True))
 
     for _target, _source in links.items():
@@ -154,14 +158,16 @@ def cmd_link(args, config):
         if not os.path.isdir(target_parent_dir):
             if do_confirm and not yes:
                 if not confirm(
-                    '\n\nCreate target parent dir(s) [ {} ] for symlink [ {} ] ?'.format(
-                    target_parent_dir, _target)):
+                    "\n\nCreate target parent dir(s) [ {} ] for symlink [ {} ] ?".format(
+                        target_parent_dir, _target
+                    )
+                ):
                     continue
             _mkdir_p(target_parent_dir)
         # create symlinks
-        msg = '{} --> {}'.format(_target, _source)
+        msg = "{} --> {}".format(_target, _source)
         if do_confirm and not yes:
-            if not confirm('Create symlink {} ?'.format(msg)):
+            if not confirm("Create symlink {} ?".format(msg)):
                 continue
         try:
             os.symlink(_source, _target)
@@ -170,18 +176,19 @@ def cmd_link(args, config):
             if err.errno != errno.EEXIST:
                 raise
             target_types = _filetype(_target)
-            if 'link' not in target_types:
+            if "link" not in target_types:
                 # Raise the OSError if target is not a symlink
                 # In this case, I'm not sure what the user expects
                 # Maybe --force could overwrite?
-                _errcho('Target [ {} ] already exists and '
-                        'is not a symlink.'.format(_target))
-            if _source == _normalize_path(
-                _target, globbing=False, resolve=True):
+                _errcho(
+                    "Target [ {} ] already exists and is not a symlink.".format(_target)
+                )
+            if _source == _normalize_path(_target, globbing=False, resolve=True):
                 if DEBUG:
-                    print_info('Skipping [ {} ]. Symlink exists and points '
-                               'to matching source [ {} ]. Skipping.'.format(
-                               _target, _source))
+                    print_info(
+                        "Skipping [ {} ]. Symlink exists and points "
+                        "to matching source [ {} ]. Skipping.".format(_target, _source)
+                    )
                 continue
             else:
                 # In this case, we could ask for confirmation,
@@ -190,11 +197,13 @@ def cmd_link(args, config):
                 # thus it should be a relatively safe thing to do,
                 # since we could do it without affecting the
                 # other (previous) source file/dir.
-                _errcho('Symlink {} already exists but does not point '
-                        'to source {}. Not creating'.format(_target, _source))
+                _errcho(
+                    "Symlink {} already exists but does not point "
+                    "to source {}. Not creating".format(_target, _source)
+                )
                 continue
         else:
-            print_success('Created symlink: {} --> {}'.format(_target, _source))
+            print_success("Created symlink: {} --> {}".format(_target, _source))
 
 
 def cmd_unlink(args, config):
@@ -204,28 +213,26 @@ def cmd_unlink(args, config):
     yes = args.yes
     target = args.target
 
-    links = (config.get('links', {}) or {}) if use_config else {}
+    links = (config.get("links", {}) or {}) if use_config else {}
     if target:
         source = _normalize_path(target, globbing=False)
         target = _normalize_path(target, resolve=False, globbing=False)
         links[target] = source
     links = _resolve_all_links(links, config)
-    links = sorted([_l for _l in links.keys()
-                    if os.path.exists(_l)], reverse=True)
+    links = sorted([_l for _l in links.keys() if os.path.exists(_l)], reverse=True)
     if DEBUG:
-        print_info('Links found to remove:')
+        print_info("Links found to remove:")
         print_info(json.dumps(links, indent=2, sort_keys=True))
     for _target in links:
         # remove symlinks
         if not os.path.islink(_target):
-            print_warning('[ {} ] is not a symlink, skipping'.format(_target))
+            print_warning("[ {} ] is not a symlink, skipping".format(_target))
             continue
-        msg = '{} (points to {} )'.format(
-            _target, _normalize_path(_target))
+        msg = "{} (points to {} )".format(_target, _normalize_path(_target))
         if do_confirm and not yes:
-            if not confirm('Remove {} ?'.format(msg)):
+            if not confirm("Remove {} ?".format(msg)):
                 continue
-        print_success('Removing symlink: {}'.format(_target))
+        print_success("Removing symlink: {}".format(_target))
         os.unlink(_target)
 
 
@@ -233,16 +240,17 @@ def _resolve_all_links(links, config):
     links_expanded = {}
     for target, source in links.items():
         if target and not source:
-            _errcho('You specified a target {} but no source'.format(target))
+            _errcho("You specified a target {} but no source".format(target))
         if source:
             source = _resolve_source(source)
         if target:
-            target = _normalize_path(
-                target, globbing=False, resolve=False).rstrip(os.path.sep)
+            target = _normalize_path(target, globbing=False, resolve=False).rstrip(
+                os.path.sep
+            )
         else:
             target = _normalize_path(
-                config['home'],
-                globbing=False, resolve=False).rstrip(os.path.sep)
+                config["home"], globbing=False, resolve=False
+            ).rstrip(os.path.sep)
             # special case:
             # we want to write _into_ the home dir, not overwrite it
             source = source if isinstance(source, list) else [source]
@@ -255,9 +263,11 @@ def _resolve_all_links(links, config):
             # isdir() will resolve a symlink dir
             if not os.path.isdir(target):
                 # consider moving this check to the link() or unlink() funcs
-                _errcho('target ( {} ) already exists and is not a directory. '
-                        'Cannot write multiple symlinks from the following '
-                        'sources into this target: {}'.format(target, source))
+                _errcho(
+                    "target ( {} ) already exists and is not a directory. "
+                    "Cannot write multiple symlinks from the following "
+                    "sources into this target: {}".format(target, source)
+                )
             for _s in source:
                 _, tail = os.path.split(_s)
                 # is this right?
@@ -276,7 +286,7 @@ def _resolve_source(source):
     # at this point we have 1 or more sources
     # source may be a single dir, a single file, or a bunch of files like ones/in/here/*
     if not abs_sources:
-        _errcho('Bad symlink source (nothing matched/found): {}'.format(source))
+        _errcho("Bad symlink source (nothing matched/found): {}".format(source))
     if len(abs_sources) == 1:
         # No globbing occurred, we want to write the source/target explicitly
         # Return a string instead of a list in this case, to indicate this
@@ -298,40 +308,73 @@ def _mkdir_p(path):
 
 def main():
     """Main entry point for dot CLI."""
-    parser = argparse.ArgumentParser(
-        prog='dot',
-        description='Dotfiles symlink manager'
+    parser = argparse.ArgumentParser(prog="dot", description="Dotfiles symlink manager")
+    parser.add_argument("--version", action="version", version="dot {}".format(VERSION))
+    parser.add_argument(
+        "--config",
+        "-c",
+        default=DEFAULT_CONFIG,
+        help="dotfiles config file (default: {})".format(DEFAULT_CONFIG),
     )
-    parser.add_argument('--version', action='version', version='dot {}'.format(VERSION))
-    parser.add_argument('--config', '-c', default=DEFAULT_CONFIG,
-                        help='dotfiles config file (default: {})'.format(DEFAULT_CONFIG))
-    parser.add_argument('--debug', action='store_true', default=False,
-                        help='enable debug output')
-    parser.add_argument('--home-dir', default=_normalize_path('~/', globbing=False),
-                        help='home directory (default: ~)')
+    parser.add_argument(
+        "--debug", action="store_true", default=False, help="enable debug output"
+    )
+    parser.add_argument(
+        "--home-dir",
+        default=_normalize_path("~/", globbing=False),
+        help="home directory (default: ~)",
+    )
 
-    subparsers = parser.add_subparsers(dest='command', help='available commands')
+    subparsers = parser.add_subparsers(dest="command", help="available commands")
 
     # link command
-    link_parser = subparsers.add_parser('link', help='Create symlinks')
-    link_parser.add_argument('-s', '--source', help='Symlink source file/dir to link to')
-    link_parser.add_argument('-t', '--target', help='Symlink target file/dir')
-    link_parser.add_argument('--skip-config', action='store_true', default=False,
-                             help='Do not use config file')
-    link_parser.add_argument('--no-confirm', action='store_true', default=False,
-                             help='Do not ask for confirmation')
-    link_parser.add_argument('-y', '--yes', action='store_true', default=False,
-                             help='Answer yes to all prompts')
+    link_parser = subparsers.add_parser("link", help="Create symlinks")
+    link_parser.add_argument(
+        "-s", "--source", help="Symlink source file/dir to link to"
+    )
+    link_parser.add_argument("-t", "--target", help="Symlink target file/dir")
+    link_parser.add_argument(
+        "--skip-config",
+        action="store_true",
+        default=False,
+        help="Do not use config file",
+    )
+    link_parser.add_argument(
+        "--no-confirm",
+        action="store_true",
+        default=False,
+        help="Do not ask for confirmation",
+    )
+    link_parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        default=False,
+        help="Answer yes to all prompts",
+    )
 
     # unlink command
-    unlink_parser = subparsers.add_parser('unlink', help='Remove symlinks')
-    unlink_parser.add_argument('-t', '--target', help='Symlink target file/dir')
-    unlink_parser.add_argument('--skip-config', action='store_true', default=False,
-                                help='Do not use config file')
-    unlink_parser.add_argument('--no-confirm', action='store_true', default=False,
-                                help='Do not ask for confirmation')
-    unlink_parser.add_argument('-y', '--yes', action='store_true', default=False,
-                                help='Answer yes to all prompts')
+    unlink_parser = subparsers.add_parser("unlink", help="Remove symlinks")
+    unlink_parser.add_argument("-t", "--target", help="Symlink target file/dir")
+    unlink_parser.add_argument(
+        "--skip-config",
+        action="store_true",
+        default=False,
+        help="Do not use config file",
+    )
+    unlink_parser.add_argument(
+        "--no-confirm",
+        action="store_true",
+        default=False,
+        help="Do not ask for confirmation",
+    )
+    unlink_parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        default=False,
+        help="Answer yes to all prompts",
+    )
 
     args = parser.parse_args()
 
@@ -346,21 +389,21 @@ def main():
         config = load_config(args.config)
 
     # Set home directory in config if not already set
-    if not config.get('home'):
-        config['home'] = args.home_dir
+    if not config.get("home"):
+        config["home"] = args.home_dir
 
     if DEBUG:
-        print_info('Config:')
+        print_info("Config:")
         print_info(json.dumps(config, indent=2, sort_keys=True))
 
     # Dispatch to command
-    if args.command == 'link':
+    if args.command == "link":
         cmd_link(args, config)
-    elif args.command == 'unlink':
+    elif args.command == "unlink":
         cmd_unlink(args, config)
     else:
         parser.print_help()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,6 @@ Pytest configuration and fixtures for dotfiles testing
 """
 
 import os
-import tempfile
-import shutil
 import pytest
 
 
@@ -73,7 +71,7 @@ def existing_symlink(home_dir, dotfiles_repo):
 def existing_file(home_dir):
     """Create an existing regular file for testing"""
     filepath = os.path.join(home_dir, ".existing_file")
-    with open(filepath, 'w') as f:
+    with open(filepath, "w") as f:
         f.write("existing content\n")
     return filepath
 

--- a/tests/test_dotfiles.py
+++ b/tests/test_dotfiles.py
@@ -5,11 +5,9 @@ Tests for dot.py - Verifies behavior of zero-dependency refactored version.
 
 import os
 import sys
-import tempfile
-import pytest
 
 # Add parent directory to path so we can import dot
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import dot
 
@@ -20,50 +18,52 @@ class TestPathResolution:
     def test_normalize_path_expanduser(self, temp_dir):
         """Test that ~/path expands to home directory"""
         # Save original HOME
-        original_home = os.environ.get('HOME')
+        original_home = os.environ.get("HOME")
 
         try:
             # Set HOME to temp_dir for testing
-            os.environ['HOME'] = str(temp_dir)
+            os.environ["HOME"] = str(temp_dir)
 
-            result = dot._normalize_path('~/testfile', globbing=False, resolve=False)
+            result = dot._normalize_path("~/testfile", globbing=False, resolve=False)
 
             # Should expand tilde to temp_dir
             assert result.startswith(str(temp_dir))
-            assert result.endswith('testfile')
+            assert result.endswith("testfile")
 
         finally:
             # Restore original HOME
             if original_home:
-                os.environ['HOME'] = original_home
+                os.environ["HOME"] = original_home
 
     def test_normalize_path_expandvars(self, temp_dir):
         """Test that $HOME/path expands correctly"""
-        original_home = os.environ.get('HOME')
+        original_home = os.environ.get("HOME")
 
         try:
-            os.environ['HOME'] = str(temp_dir)
+            os.environ["HOME"] = str(temp_dir)
 
-            result = dot._normalize_path('$HOME/testfile', globbing=False, resolve=False)
+            result = dot._normalize_path(
+                "$HOME/testfile", globbing=False, resolve=False
+            )
 
             assert result.startswith(str(temp_dir))
-            assert result.endswith('testfile')
+            assert result.endswith("testfile")
 
         finally:
             if original_home:
-                os.environ['HOME'] = original_home
+                os.environ["HOME"] = original_home
 
     def test_normalize_path_with_globbing(self, dotfiles_repo):
         """Test that glob patterns expand to list of files"""
-        glob_pattern = os.path.join(dotfiles_repo, 'test', 'vim', '*')
+        glob_pattern = os.path.join(dotfiles_repo, "test", "vim", "*")
 
         result = dot._normalize_path(glob_pattern, globbing=True)
 
         # Should return a list of files
         assert isinstance(result, list)
         assert len(result) == 2  # vimrc and plugin.vim
-        assert any('vimrc' in f for f in result)
-        assert any('plugin.vim' in f for f in result)
+        assert any("vimrc" in f for f in result)
+        assert any("plugin.vim" in f for f in result)
 
     def test_normalize_path_realpath(self, temp_dir):
         """Test that realpath resolution works"""
@@ -85,21 +85,21 @@ class TestFiletype:
         """Test that symlinks are detected"""
         types = list(dot._filetype(existing_symlink))
 
-        assert 'link' in types
+        assert "link" in types
 
     def test_filetype_detects_file(self, existing_file):
         """Test that regular files are detected"""
         types = list(dot._filetype(existing_file))
 
-        assert 'file' in types
-        assert 'link' not in types
+        assert "file" in types
+        assert "link" not in types
 
     def test_filetype_detects_dir(self, existing_dir):
         """Test that directories are detected"""
         types = list(dot._filetype(existing_dir))
 
-        assert 'dir' in types
-        assert 'link' not in types
+        assert "dir" in types
+        assert "link" not in types
 
 
 class TestResolveSource:
@@ -107,7 +107,7 @@ class TestResolveSource:
 
     def test_resolve_source_single_file(self, dotfiles_repo):
         """Test resolving a single file source"""
-        source = os.path.join(dotfiles_repo, 'test', 'testrc')
+        source = os.path.join(dotfiles_repo, "test", "testrc")
 
         result = dot._resolve_source(source)
 
@@ -117,7 +117,7 @@ class TestResolveSource:
 
     def test_resolve_source_glob_pattern(self, dotfiles_repo):
         """Test resolving glob pattern source"""
-        source = os.path.join(dotfiles_repo, 'test', 'vim', '*')
+        source = os.path.join(dotfiles_repo, "test", "vim", "*")
 
         result = dot._resolve_source(source)
 
@@ -173,12 +173,12 @@ class TestIssue3Fixed:
         The continue statement should NOT be inside a DEBUG block.
         """
         # Read dot.py to verify it exists and has been refactored
-        dot_path = os.path.join(os.path.dirname(__file__), '..', 'dot.py')
-        with open(dot_path, 'r') as f:
+        dot_path = os.path.join(os.path.dirname(__file__), "..", "dot.py")
+        with open(dot_path, "r") as f:
             content = f.read()
 
         # Verify the file has been refactored with argparse
-        assert 'def cmd_link' in content or 'def main' in content
+        assert "def cmd_link" in content or "def main" in content
         # The bug has been fixed in the refactored version
         pass
 


### PR DESCRIPTION
## Summary

Audited the repo's CI (three overlapping workflows) and consolidated into one, after making the Python pass the quality gates. Built spec → validate → plan → validate → subagent execution → polish-pr.

### 1. Python lint/type fixes (`fix(python)`)
- Removed 4 unused imports (`tempfile`/`shutil` in `conftest.py`; `tempfile`/`pytest` in `test_dotfiles.py`)
- `ruff format` on `dot.py` + the two test files — a one-time Black-style normalization (provably behavior-neutral: zero net token change)
- `# type: ignore[name-defined]` on the `input = raw_input` line — **keeps the Python 2.7 shim**, silences the one mypy error
- No `[tool.ruff]`/`[tool.mypy]` config added; Py2 classifiers / `requires-python` untouched

### 2. CI consolidation (`ci`)
- `test.yml` now installs tools from the pinned `requirements-quality.txt` and runs `ruff check` → `ruff format --check` → `mypy` (after shellcheck, before pytest), on both macOS + Ubuntu
- **Removed two untracked WIP workflows from the working tree**: `python-quality.yml` (its pytest duplicated `test.yml`) and `shellcheck.yml` (subsumed below). These were never committed to `main`.
- Single workflow now: shellcheck → ruff → format → mypy → pytest → validation bats → benchmark bats

### 3. Hardened the ShellCheck gate (`ci`)
The consolidated ShellCheck step is now **stronger** than either prior workflow:
- **Shebang-based detection over git-tracked files** — every tracked shell script is linted by its `#!` line, so extensionless scripts (git hooks, `bin/` tools) are covered too, not just `*.sh` by name. Scanning git-tracked files matches what CI checks out and auto-skips gitignored/vendored content (e.g. `autocomplete/`).
- **Blanket-disable policy (blocking)** — re-adds the "no global `# shellcheck disable=`" rule the never-run `shellcheck.yml` carried, with a *correct* heuristic: a disable must annotate the next code line; one followed by a blank/comment is a forbidden file-level suppression. (The original first-20-lines heuristic false-positived on legit per-line disables.)
- 32 tracked scripts covered; lint + policy both clean and blocking.

## Test plan
- [x] `ruff check .` / `ruff format --check .` / `mypy . --ignore-missing-imports` → all clean locally
- [x] `pytest tests/` → 12/12 pass (confirms the import removals were safe)
- [x] ShellCheck gate: 32 tracked scripts, lint + blanket-disable policy both clean; verified the step body exits 0 under GHA's `bash -eo pipefail`, and that the policy correctly *fails* on a synthetic blanket disable
- [x] `test.yml` is valid YAML
- [x] **CI green on macOS + Ubuntu** — the consolidated `test.yml` (see checks)
- [x] Two independent code reviews (pr-review-toolkit + superpowers) — no Critical/Important