### PR TITLE
New-machine setup: portable shell startup, YAML config support, login-shell bootstrap, Terminal.app Shift+Enter

### DIFF
--- a/README-dot.md
+++ b/README-dot.md
@@ -11,6 +11,7 @@ A lightweight, zero-dependency dotfiles symlink manager for Unix systems. Single
 - **Python 2.7+ and 3.6+ compatible** - Works on old servers and modern systems
 - **Single file** - Easy to curl and run directly
 - **JSON configuration** - Simple, readable config format
+- **Optional YAML configuration** - `dotfiles.yaml`/`.yml` works when PyYAML is installed (never required; JSON always works)
 - **Glob pattern support** - Link multiple files with wildcards
 - **Smart conflict handling** - Detects existing files and symlinks
 - **Cross-platform** - Works on macOS, Linux, BSD, and other Unix systems

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ cd ~/dotfiles
 
 Restart your terminal.
 
+`install.sh` also checks that your login shell is a modern bash (the dotfiles
+only load under bash) and offers to switch it — it always asks first, and
+prints the manual `chsh` commands instead when run non-interactively.
+
 ## What's Included
 
 - **Bash**: Fast startup, git-aware prompt, cross-platform completions

--- a/bash/bash_profile
+++ b/bash/bash_profile
@@ -150,7 +150,11 @@ set +e
 trap - ERR
 
 # add Pulumi to the PATH
-[ -d "$HOME/.pulumi/bin" ] && export PATH="$PATH:$HOME/.pulumi/bin"
+if [ -d "$HOME/.pulumi/bin" ]; then
+  export PATH="$PATH:$HOME/.pulumi/bin"
+fi
 
-test -e "${HOME}/.iterm2_shell_integration.bash" && source "${HOME}/.iterm2_shell_integration.bash"
+if test -e "${HOME}/.iterm2_shell_integration.bash"; then
+  source "${HOME}/.iterm2_shell_integration.bash"
+fi
 

--- a/dot.py
+++ b/dot.py
@@ -21,6 +21,13 @@ try:
 except NameError:
     pass  # Python 3
 
+# Optional YAML config support. PyYAML must never be a hard requirement:
+# dot.py is zero-dependency and JSON always works.
+try:
+    import yaml  # type: ignore[import-untyped]
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
 VERSION = "1.0.0"
 DEFAULT_CONFIG = "dotfiles.json"
 DEBUG = False
@@ -123,11 +130,27 @@ def _filetype(path):
 
 
 def load_config(config_path):
-    """Load config from JSON file."""
+    """Load config from a JSON or YAML file.
+
+    YAML configs require PyYAML; JSON configs always work.
+    """
+    load_errors = (
+        (IOError, ValueError) if yaml is None else (IOError, ValueError, yaml.YAMLError)
+    )
     try:
         with open(config_path, "r") as f:
+            if config_path.endswith((".yaml", ".yml")):
+                if yaml is None:
+                    print_error(
+                        "{} is a YAML config but PyYAML is not installed. "
+                        "Install it (pip install PyYAML) or use a JSON config.".format(
+                            config_path
+                        )
+                    )
+                    return {}
+                return yaml.safe_load(f) or {}
             return json.load(f)
-    except (IOError, ValueError) as e:
+    except load_errors as e:
         print_error("Failed to load config file {}: {}".format(config_path, e))
         return {}
 
@@ -314,7 +337,8 @@ def main():
         "--config",
         "-c",
         default=DEFAULT_CONFIG,
-        help="dotfiles config file (default: {})".format(DEFAULT_CONFIG),
+        help="dotfiles config file, JSON or YAML (default: {}, "
+        "falling back to dotfiles.yaml; YAML requires PyYAML)".format(DEFAULT_CONFIG),
     )
     parser.add_argument(
         "--debug", action="store_true", default=False, help="enable debug output"
@@ -385,8 +409,15 @@ def main():
 
     # Load config if it exists
     config = {}
-    if os.path.isfile(args.config):
-        config = load_config(args.config)
+    config_path = args.config
+    if config_path == DEFAULT_CONFIG and not os.path.isfile(config_path):
+        # Fall back to a YAML config when the default JSON one is absent
+        for candidate in ("dotfiles.yaml", "dotfiles.yml"):
+            if os.path.isfile(candidate):
+                config_path = candidate
+                break
+    if os.path.isfile(config_path):
+        config = load_config(config_path)
 
     # Set home directory in config if not already set
     if not config.get("home"):

--- a/dotfiles.json
+++ b/dotfiles.json
@@ -1,0 +1,19 @@
+{
+  "home": "~",
+  "dotfiles": "~/dotfiles",
+  "links": {
+    "~/.bash_profile": "bash/bash_profile",
+    "~/.bash_aliases": "bash/bash_aliases",
+    "~/.bashrc": "bash/bashrc",
+    "~/.vimrc": "vim/vimrc",
+    "~/.vim/samstav-vimrc": "vim/samstav-vimrc",
+    "~/.config/nvim/init.vim": "vim/vimrc",
+    "~/.tmux.conf": "tmux/tmux.conf",
+    "~/.gitignore_global": "git/gitignore_global",
+    "~/.gitconfig": "git/gitconfig",
+    "~/.config/karabiner/karabiner.json": "karabiner/karabiner.json",
+    "~/.inputrc": "osx/inputrc",
+    "~/.config/base16-shell": "shell/base16-shell",
+    "~/.config/tmux-claude-resume/": "tmux-claude-resume/*"
+  }
+}

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,9 @@
 # - pyenv (Python version manager via pyenv-installer)
 # - pyenv-virtualenvwrapper (Python virtual environment tools)
 #
+# Also checks that the login shell is a modern bash (the dotfiles are
+# bash-centric) and offers to switch it — always asks first.
+#
 # Note: This script only installs missing components. It does not update
 # existing installations. Use the appropriate update method for each tool:
 #   - vim-plug: Run :PlugUpdate in Vim
@@ -61,8 +64,10 @@ fi
 # Python Environment Manager (pyenv)
 # ============================================================================
 
-# Check if pyenv is already working
-if command -v pyenv &>/dev/null && [[ -d ~/.pyenv ]]; then
+# Check if pyenv is already installed. Look in ~/.pyenv/bin too: pyenv is
+# only on PATH once the dotfiles are loaded, and this script must stay
+# idempotent when run from a stock shell.
+if [[ -d ~/.pyenv ]] && { command -v pyenv &>/dev/null || [[ -x "${HOME}/.pyenv/bin/pyenv" ]]; }; then
     echo "✓ pyenv already installed"
     export PATH="${HOME}/.pyenv/bin:$PATH"
     # Detect shell type for cross-shell compatibility
@@ -94,6 +99,84 @@ if [[ -d "$VENVWRAPPER_DIR" ]]; then
 else
     echo "Installing pyenv-virtualenvwrapper..."
     git clone https://github.com/pyenv/pyenv-virtualenvwrapper.git "$VENVWRAPPER_DIR"
+fi
+
+# ============================================================================
+# Login Shell (optional)
+# ============================================================================
+#
+# The dotfiles are bash-centric (~/.bash_profile, ~/.bashrc, modules/) and
+# only load when bash is the login shell. macOS defaults to zsh and ships
+# bash 3.2; the config needs bash 4.3+ (macOS: bash 5+ via `brew install
+# bash`). Detect the situation and offer to switch. Never switches without
+# asking; prints the manual commands when run non-interactively.
+
+echo ""
+echo "Checking login shell..."
+
+# Require bash >= 4.3
+_bash_version_ok() {
+    local major minor
+    # shellcheck disable=SC2016  # expand in the candidate bash, not here
+    major="$("$1" -c 'echo "${BASH_VERSINFO[0]}"' 2>/dev/null)" || return 1
+    # shellcheck disable=SC2016  # expand in the candidate bash, not here
+    minor="$("$1" -c 'echo "${BASH_VERSINFO[1]}"' 2>/dev/null)" || return 1
+    [[ "$major" -gt 4 ]] || [[ "$major" -eq 4 && "$minor" -ge 3 ]]
+}
+
+current_user="${USER:-$(id -un)}"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    login_shell="$(dscl . -read "/Users/${current_user}" UserShell 2>/dev/null | awk '{print $2}')"
+else
+    login_shell="$(getent passwd "${current_user}" 2>/dev/null | cut -d: -f7)"
+fi
+login_shell="${login_shell:-${SHELL:-unknown}}"
+
+brew_prefix="$(brew --prefix 2>/dev/null || true)"
+preferred_bash=""
+for candidate in "${brew_prefix:+${brew_prefix}/bin/bash}" /opt/homebrew/bin/bash /usr/local/bin/bash /usr/bin/bash /bin/bash; do
+    [[ -n "$candidate" && -x "$candidate" ]] || continue
+    if _bash_version_ok "$candidate"; then
+        preferred_bash="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$preferred_bash" ]]; then
+    echo "⚠️  No bash >= 4.3 found; the dotfiles will not load without one."
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        echo "   Install one with: brew install bash  (then re-run ./install.sh)"
+    fi
+elif [[ "$login_shell" == "$preferred_bash" ]]; then
+    echo "✓ Login shell is already ${preferred_bash}"
+else
+    echo "Your login shell is ${login_shell}, but these dotfiles only load under bash."
+    echo "Suitable bash found: ${preferred_bash}"
+    change_shell="no"
+    if [[ -t 0 ]]; then
+        read -r -p "Change your login shell to ${preferred_bash}? [y/N] " reply
+        [[ "$reply" =~ ^[Yy]([Ee][Ss])?$ ]] && change_shell="yes"
+    else
+        echo "(non-interactive run — not changing your shell)"
+    fi
+    if [[ "$change_shell" == "yes" ]]; then
+        # chsh only accepts shells listed in /etc/shells
+        if ! grep -qx "$preferred_bash" /etc/shells; then
+            echo "Adding ${preferred_bash} to /etc/shells (requires sudo)..."
+            echo "$preferred_bash" | sudo tee -a /etc/shells >/dev/null
+        fi
+        if chsh -s "$preferred_bash"; then
+            echo "✓ Login shell changed to ${preferred_bash} (takes effect in new terminals)"
+        else
+            echo "⚠️  chsh failed; login shell unchanged."
+            change_shell="no"
+        fi
+    fi
+    if [[ "$change_shell" == "no" ]]; then
+        echo "To change it later:"
+        echo "  grep -qx '${preferred_bash}' /etc/shells || echo '${preferred_bash}' | sudo tee -a /etc/shells"
+        echo "  chsh -s '${preferred_bash}'"
+    fi
 fi
 
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -49,6 +49,16 @@ else
         https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 fi
 
+# Neovim shares the vimrc (linked to ~/.config/nvim/init.vim) but looks for
+# autoload scripts under its own data dir, not ~/.vim
+if [[ -f ~/.local/share/nvim/site/autoload/plug.vim ]]; then
+    echo "✓ vim-plug (neovim) already installed"
+else
+    echo "Installing vim-plug for neovim..."
+    curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs \
+        https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+fi
+
 # ============================================================================
 # TMUX Plugin Manager (TPM)
 # ============================================================================

--- a/karabiner/karabiner.json
+++ b/karabiner/karabiner.json
@@ -110,6 +110,38 @@
                                 "type": "basic"
                             }
                         ]
+                    },
+                    {
+                        "description": "Terminal.app: shift+return sends escape,return (newline in Claude Code etc.)",
+                        "manipulators": [
+                            {
+                                "type": "basic",
+                                "conditions": [
+                                    {
+                                        "type": "frontmost_application_if",
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$"
+                                        ]
+                                    }
+                                ],
+                                "from": {
+                                    "key_code": "return_or_enter",
+                                    "modifiers": {
+                                        "mandatory": [
+                                            "shift"
+                                        ]
+                                    }
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "escape"
+                                    },
+                                    {
+                                        "key_code": "return_or_enter"
+                                    }
+                                ]
+                            }
+                        ]
                     }
                 ]
             },
@@ -471,6 +503,38 @@
                                     }
                                 ],
                                 "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Terminal.app: shift+return sends escape,return (newline in Claude Code etc.)",
+                        "manipulators": [
+                            {
+                                "type": "basic",
+                                "conditions": [
+                                    {
+                                        "type": "frontmost_application_if",
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$"
+                                        ]
+                                    }
+                                ],
+                                "from": {
+                                    "key_code": "return_or_enter",
+                                    "modifiers": {
+                                        "mandatory": [
+                                            "shift"
+                                        ]
+                                    }
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "escape"
+                                    },
+                                    {
+                                        "key_code": "return_or_enter"
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/karabiner/karabiner.json
+++ b/karabiner/karabiner.json
@@ -1,19 +1,7 @@
 {
-    "global": {
-        "check_for_updates_on_startup": true,
-        "show_in_menu_bar": true,
-        "show_profile_name_in_menu_bar": false
-    },
     "profiles": [
         {
             "complex_modifications": {
-                "parameters": {
-                    "basic.simultaneous_threshold_milliseconds": 50,
-                    "basic.to_delayed_action_delay_milliseconds": 500,
-                    "basic.to_if_alone_timeout_milliseconds": 1000,
-                    "basic.to_if_held_down_threshold_milliseconds": 500,
-                    "mouse_motion_to_scroll.speed": 100
-                },
                 "rules": [
                     {
                         "manipulators": [
@@ -22,19 +10,11 @@
                                 "from": {
                                     "key_code": "h",
                                     "modifiers": {
-                                        "mandatory": [
-                                            "right_control"
-                                        ],
-                                        "optional": [
-                                            "caps_lock"
-                                        ]
+                                        "mandatory": ["right_control"],
+                                        "optional": ["caps_lock"]
                                     }
                                 },
-                                "to": [
-                                    {
-                                        "key_code": "left_arrow"
-                                    }
-                                ],
+                                "to": [{ "key_code": "left_arrow" }],
                                 "type": "basic"
                             }
                         ]
@@ -46,19 +26,11 @@
                                 "from": {
                                     "key_code": "l",
                                     "modifiers": {
-                                        "mandatory": [
-                                            "right_control"
-                                        ],
-                                        "optional": [
-                                            "caps_lock"
-                                        ]
+                                        "mandatory": ["right_control"],
+                                        "optional": ["caps_lock"]
                                     }
                                 },
-                                "to": [
-                                    {
-                                        "key_code": "right_arrow"
-                                    }
-                                ],
+                                "to": [{ "key_code": "right_arrow" }],
                                 "type": "basic"
                             }
                         ]
@@ -70,19 +42,11 @@
                                 "from": {
                                     "key_code": "k",
                                     "modifiers": {
-                                        "mandatory": [
-                                            "right_control"
-                                        ],
-                                        "optional": [
-                                            "caps_lock"
-                                        ]
+                                        "mandatory": ["right_control"],
+                                        "optional": ["caps_lock"]
                                     }
                                 },
-                                "to": [
-                                    {
-                                        "key_code": "up_arrow"
-                                    }
-                                ],
+                                "to": [{ "key_code": "up_arrow" }],
                                 "type": "basic"
                             }
                         ]
@@ -94,19 +58,11 @@
                                 "from": {
                                     "key_code": "j",
                                     "modifiers": {
-                                        "mandatory": [
-                                            "right_control"
-                                        ],
-                                        "optional": [
-                                            "caps_lock"
-                                        ]
+                                        "mandatory": ["right_control"],
+                                        "optional": ["caps_lock"]
                                     }
                                 },
-                                "to": [
-                                    {
-                                        "key_code": "down_arrow"
-                                    }
-                                ],
+                                "to": [{ "key_code": "down_arrow" }],
                                 "type": "basic"
                             }
                         ]
@@ -115,31 +71,23 @@
                         "description": "Terminal.app: shift+return sends escape,return (newline in Claude Code etc.)",
                         "manipulators": [
                             {
-                                "type": "basic",
                                 "conditions": [
                                     {
-                                        "type": "frontmost_application_if",
                                         "bundle_identifiers": [
                                             "^com\\.apple\\.Terminal$"
-                                        ]
+                                        ],
+                                        "type": "frontmost_application_if"
                                     }
                                 ],
                                 "from": {
                                     "key_code": "return_or_enter",
-                                    "modifiers": {
-                                        "mandatory": [
-                                            "shift"
-                                        ]
-                                    }
+                                    "modifiers": { "mandatory": ["shift"] }
                                 },
                                 "to": [
-                                    {
-                                        "key_code": "escape"
-                                    },
-                                    {
-                                        "key_code": "return_or_enter"
-                                    }
-                                ]
+                                    { "key_code": "escape" },
+                                    { "key_code": "return_or_enter" }
+                                ],
+                                "type": "basic"
                             }
                         ]
                     }
@@ -147,187 +95,102 @@
             },
             "devices": [
                 {
-                    "disable_built_in_keyboard_if_exists": false,
-                    "fn_function_keys": [],
                     "identifiers": {
                         "is_keyboard": true,
-                        "is_pointing_device": false,
                         "product_id": 257,
                         "vendor_id": 1204
                     },
-                    "ignore": false,
                     "manipulate_caps_lock_led": false,
                     "simple_modifications": [
                         {
-                            "from": {
-                                "key_code": "left_command"
-                            },
-                            "to": {
-                                "key_code": "left_option"
-                            }
+                            "from": { "key_code": "left_command" },
+                            "to": [{ "key_code": "left_option" }]
                         },
                         {
-                            "from": {
-                                "key_code": "right_option"
-                            },
-                            "to": {
-                                "key_code": "right_command"
-                            }
+                            "from": { "key_code": "right_option" },
+                            "to": [{ "key_code": "right_command" }]
                         }
                     ]
                 },
                 {
-                    "disable_built_in_keyboard_if_exists": false,
-                    "fn_function_keys": [],
                     "identifiers": {
                         "is_keyboard": true,
-                        "is_pointing_device": false,
                         "product_id": 34304,
                         "vendor_id": 1452
                     },
-                    "ignore": false,
-                    "manipulate_caps_lock_led": true,
                     "simple_modifications": [
                         {
-                            "from": {
-                                "key_code": "right_option"
-                            },
-                            "to": {
-                                "key_code": "left_command"
-                            }
+                            "from": { "key_code": "right_option" },
+                            "to": [{ "key_code": "left_command" }]
                         }
                     ]
                 }
             ],
             "fn_function_keys": [
                 {
-                    "from": {
-                        "key_code": "f1"
-                    },
-                    "to": {
-                        "key_code": "display_brightness_decrement"
-                    }
+                    "from": { "key_code": "f1" },
+                    "to": [{ "key_code": "display_brightness_decrement" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f2"
-                    },
-                    "to": {
-                        "key_code": "display_brightness_increment"
-                    }
+                    "from": { "key_code": "f2" },
+                    "to": [{ "key_code": "display_brightness_increment" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f3"
-                    },
-                    "to": {
-                        "key_code": "mission_control"
-                    }
+                    "from": { "key_code": "f3" },
+                    "to": [{ "key_code": "mission_control" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f4"
-                    },
-                    "to": {
-                        "key_code": "launchpad"
-                    }
+                    "from": { "key_code": "f4" },
+                    "to": [{ "key_code": "launchpad" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f5"
-                    },
-                    "to": {
-                        "key_code": "illumination_decrement"
-                    }
+                    "from": { "key_code": "f5" },
+                    "to": [{ "key_code": "illumination_decrement" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f6"
-                    },
-                    "to": {
-                        "key_code": "illumination_increment"
-                    }
+                    "from": { "key_code": "f6" },
+                    "to": [{ "key_code": "illumination_increment" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f7"
-                    },
-                    "to": {
-                        "key_code": "rewind"
-                    }
+                    "from": { "key_code": "f7" },
+                    "to": [{ "key_code": "rewind" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f8"
-                    },
-                    "to": {
-                        "key_code": "play_or_pause"
-                    }
+                    "from": { "key_code": "f8" },
+                    "to": [{ "key_code": "play_or_pause" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f9"
-                    },
-                    "to": {
-                        "key_code": "fastforward"
-                    }
+                    "from": { "key_code": "f9" },
+                    "to": [{ "key_code": "fastforward" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f10"
-                    },
-                    "to": {
-                        "key_code": "mute"
-                    }
+                    "from": { "key_code": "f10" },
+                    "to": [{ "key_code": "mute" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f11"
-                    },
-                    "to": {
-                        "key_code": "volume_decrement"
-                    }
+                    "from": { "key_code": "f11" },
+                    "to": [{ "key_code": "volume_decrement" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f12"
-                    },
-                    "to": {
-                        "key_code": "volume_increment"
-                    }
+                    "from": { "key_code": "f12" },
+                    "to": [{ "key_code": "volume_increment" }]
                 }
             ],
             "name": "Default profile",
-            "parameters": {
-                "delay_milliseconds_before_open_device": 1000
-            },
-            "selected": false,
             "simple_modifications": [
                 {
-                    "from": {
-                        "key_code": "caps_lock"
-                    },
-                    "to": {
-                        "key_code": "right_control"
-                    }
+                    "from": { "key_code": "caps_lock" },
+                    "to": [{ "key_code": "right_control" }]
                 }
             ],
             "virtual_hid_keyboard": {
                 "caps_lock_delay_milliseconds": 0,
                 "country_code": 0,
-                "keyboard_type": "ansi",
-                "mouse_key_xy_scale": 100
+                "keyboard_type": "ansi"
             }
         },
         {
             "complex_modifications": {
-                "parameters": {
-                    "basic.simultaneous_threshold_milliseconds": 50,
-                    "basic.to_delayed_action_delay_milliseconds": 500,
-                    "basic.to_if_alone_timeout_milliseconds": 1000,
-                    "basic.to_if_held_down_threshold_milliseconds": 500,
-                    "mouse_motion_to_scroll.speed": 100
-                },
                 "rules": [
                     {
                         "manipulators": [
@@ -336,19 +199,11 @@
                                 "from": {
                                     "key_code": "h",
                                     "modifiers": {
-                                        "mandatory": [
-                                            "right_control"
-                                        ],
-                                        "optional": [
-                                            "caps_lock"
-                                        ]
+                                        "mandatory": ["right_control"],
+                                        "optional": ["caps_lock"]
                                     }
                                 },
-                                "to": [
-                                    {
-                                        "key_code": "left_arrow"
-                                    }
-                                ],
+                                "to": [{ "key_code": "left_arrow" }],
                                 "type": "basic"
                             }
                         ]
@@ -360,19 +215,11 @@
                                 "from": {
                                     "key_code": "l",
                                     "modifiers": {
-                                        "mandatory": [
-                                            "right_control"
-                                        ],
-                                        "optional": [
-                                            "caps_lock"
-                                        ]
+                                        "mandatory": ["right_control"],
+                                        "optional": ["caps_lock"]
                                     }
                                 },
-                                "to": [
-                                    {
-                                        "key_code": "right_arrow"
-                                    }
-                                ],
+                                "to": [{ "key_code": "right_arrow" }],
                                 "type": "basic"
                             }
                         ]
@@ -384,19 +231,11 @@
                                 "from": {
                                     "key_code": "k",
                                     "modifiers": {
-                                        "mandatory": [
-                                            "right_control"
-                                        ],
-                                        "optional": [
-                                            "caps_lock"
-                                        ]
+                                        "mandatory": ["right_control"],
+                                        "optional": ["caps_lock"]
                                     }
                                 },
-                                "to": [
-                                    {
-                                        "key_code": "up_arrow"
-                                    }
-                                ],
+                                "to": [{ "key_code": "up_arrow" }],
                                 "type": "basic"
                             }
                         ]
@@ -408,19 +247,11 @@
                                 "from": {
                                     "key_code": "j",
                                     "modifiers": {
-                                        "mandatory": [
-                                            "right_control"
-                                        ],
-                                        "optional": [
-                                            "caps_lock"
-                                        ]
+                                        "mandatory": ["right_control"],
+                                        "optional": ["caps_lock"]
                                     }
                                 },
-                                "to": [
-                                    {
-                                        "key_code": "down_arrow"
-                                    }
-                                ],
+                                "to": [{ "key_code": "down_arrow" }],
                                 "type": "basic"
                             }
                         ]
@@ -432,76 +263,44 @@
                                 "from": {
                                     "key_code": "h",
                                     "modifiers": {
-                                        "mandatory": [
-                                            "left_control"
-                                        ],
-                                        "optional": [
-                                            "any"
-                                        ]
+                                        "mandatory": ["left_control"],
+                                        "optional": ["any"]
                                     }
                                 },
-                                "to": [
-                                    {
-                                        "key_code": "left_arrow"
-                                    }
-                                ],
+                                "to": [{ "key_code": "left_arrow" }],
                                 "type": "basic"
                             },
                             {
                                 "from": {
                                     "key_code": "j",
                                     "modifiers": {
-                                        "mandatory": [
-                                            "left_control"
-                                        ],
-                                        "optional": [
-                                            "any"
-                                        ]
+                                        "mandatory": ["left_control"],
+                                        "optional": ["any"]
                                     }
                                 },
-                                "to": [
-                                    {
-                                        "key_code": "down_arrow"
-                                    }
-                                ],
+                                "to": [{ "key_code": "down_arrow" }],
                                 "type": "basic"
                             },
                             {
                                 "from": {
                                     "key_code": "k",
                                     "modifiers": {
-                                        "mandatory": [
-                                            "left_control"
-                                        ],
-                                        "optional": [
-                                            "any"
-                                        ]
+                                        "mandatory": ["left_control"],
+                                        "optional": ["any"]
                                     }
                                 },
-                                "to": [
-                                    {
-                                        "key_code": "up_arrow"
-                                    }
-                                ],
+                                "to": [{ "key_code": "up_arrow" }],
                                 "type": "basic"
                             },
                             {
                                 "from": {
                                     "key_code": "l",
                                     "modifiers": {
-                                        "mandatory": [
-                                            "left_control"
-                                        ],
-                                        "optional": [
-                                            "any"
-                                        ]
+                                        "mandatory": ["left_control"],
+                                        "optional": ["any"]
                                     }
                                 },
-                                "to": [
-                                    {
-                                        "key_code": "right_arrow"
-                                    }
-                                ],
+                                "to": [{ "key_code": "right_arrow" }],
                                 "type": "basic"
                             }
                         ]
@@ -510,31 +309,23 @@
                         "description": "Terminal.app: shift+return sends escape,return (newline in Claude Code etc.)",
                         "manipulators": [
                             {
-                                "type": "basic",
                                 "conditions": [
                                     {
-                                        "type": "frontmost_application_if",
                                         "bundle_identifiers": [
                                             "^com\\.apple\\.Terminal$"
-                                        ]
+                                        ],
+                                        "type": "frontmost_application_if"
                                     }
                                 ],
                                 "from": {
                                     "key_code": "return_or_enter",
-                                    "modifiers": {
-                                        "mandatory": [
-                                            "shift"
-                                        ]
-                                    }
+                                    "modifiers": { "mandatory": ["shift"] }
                                 },
                                 "to": [
-                                    {
-                                        "key_code": "escape"
-                                    },
-                                    {
-                                        "key_code": "return_or_enter"
-                                    }
-                                ]
+                                    { "key_code": "escape" },
+                                    { "key_code": "return_or_enter" }
+                                ],
+                                "type": "basic"
                             }
                         ]
                     }
@@ -542,318 +333,178 @@
             },
             "devices": [
                 {
-                    "disable_built_in_keyboard_if_exists": false,
-                    "fn_function_keys": [],
                     "identifiers": {
                         "is_keyboard": true,
-                        "is_pointing_device": false,
                         "product_id": 257,
                         "vendor_id": 1204
                     },
-                    "ignore": false,
                     "manipulate_caps_lock_led": false,
                     "simple_modifications": [
                         {
-                            "from": {
-                                "key_code": "caps_lock"
-                            },
-                            "to": {
-                                "key_code": "right_control"
-                            }
+                            "from": { "key_code": "caps_lock" },
+                            "to": [{ "key_code": "right_control" }]
                         },
                         {
-                            "from": {
-                                "key_code": "left_command"
-                            },
-                            "to": {
-                                "key_code": "left_option"
-                            }
+                            "from": { "key_code": "left_command" },
+                            "to": [{ "key_code": "left_option" }]
                         },
                         {
-                            "from": {
-                                "key_code": "left_option"
-                            },
-                            "to": {
-                                "key_code": "left_command"
-                            }
+                            "from": { "key_code": "left_option" },
+                            "to": [{ "key_code": "left_command" }]
                         },
                         {
-                            "from": {
-                                "key_code": "right_command"
-                            },
-                            "to": {
-                                "key_code": "right_option"
-                            }
+                            "from": { "key_code": "right_command" },
+                            "to": [{ "key_code": "right_option" }]
                         },
                         {
-                            "from": {
-                                "key_code": "right_option"
-                            },
-                            "to": {
-                                "key_code": "right_command"
-                            }
+                            "from": { "key_code": "right_option" },
+                            "to": [{ "key_code": "right_command" }]
                         }
                     ]
                 },
                 {
-                    "disable_built_in_keyboard_if_exists": false,
-                    "fn_function_keys": [],
                     "identifiers": {
                         "is_keyboard": true,
-                        "is_pointing_device": false,
                         "product_id": 34304,
                         "vendor_id": 1452
                     },
-                    "ignore": false,
-                    "manipulate_caps_lock_led": true,
                     "simple_modifications": [
                         {
-                            "from": {
-                                "key_code": "right_option"
-                            },
-                            "to": {
-                                "key_code": "left_command"
-                            }
+                            "from": { "key_code": "right_option" },
+                            "to": [{ "key_code": "left_command" }]
                         }
                     ]
                 },
                 {
-                    "disable_built_in_keyboard_if_exists": false,
-                    "fn_function_keys": [],
                     "identifiers": {
                         "is_keyboard": true,
-                        "is_pointing_device": false,
                         "product_id": 256,
                         "vendor_id": 2131
                     },
-                    "ignore": false,
                     "manipulate_caps_lock_led": false,
                     "simple_modifications": [
                         {
-                            "from": {
-                                "key_code": "caps_lock"
-                            },
-                            "to": {
-                                "key_code": "right_control"
-                            }
+                            "from": { "key_code": "caps_lock" },
+                            "to": [{ "key_code": "right_control" }]
                         },
                         {
-                            "from": {
-                                "key_code": "escape"
-                            },
-                            "to": {
-                                "key_code": "grave_accent_and_tilde"
-                            }
+                            "from": { "key_code": "escape" },
+                            "to": [{ "key_code": "grave_accent_and_tilde" }]
                         },
                         {
-                            "from": {
-                                "key_code": "left_command"
-                            },
-                            "to": {
-                                "key_code": "left_option"
-                            }
+                            "from": { "key_code": "left_command" },
+                            "to": [{ "key_code": "left_option" }]
                         },
                         {
-                            "from": {
-                                "key_code": "left_control"
-                            },
-                            "to": {
-                                "key_code": "right_control"
-                            }
+                            "from": { "key_code": "left_control" },
+                            "to": [{ "key_code": "right_control" }]
                         },
                         {
-                            "from": {
-                                "key_code": "left_option"
-                            },
-                            "to": {
-                                "key_code": "left_command"
-                            }
+                            "from": { "key_code": "left_option" },
+                            "to": [{ "key_code": "left_command" }]
                         },
                         {
-                            "from": {
-                                "key_code": "right_command"
-                            },
-                            "to": {
-                                "key_code": "right_option"
-                            }
+                            "from": { "key_code": "right_command" },
+                            "to": [{ "key_code": "right_option" }]
                         },
                         {
-                            "from": {
-                                "key_code": "right_option"
-                            },
-                            "to": {
-                                "key_code": "right_command"
-                            }
+                            "from": { "key_code": "right_option" },
+                            "to": [{ "key_code": "right_command" }]
                         }
                     ]
                 },
                 {
-                    "disable_built_in_keyboard_if_exists": false,
-                    "fn_function_keys": [],
                     "identifiers": {
                         "is_keyboard": true,
-                        "is_pointing_device": false,
                         "product_id": 631,
                         "vendor_id": 1452
                     },
-                    "ignore": false,
-                    "manipulate_caps_lock_led": true,
                     "simple_modifications": [
                         {
-                            "from": {
-                                "key_code": "caps_lock"
-                            },
-                            "to": {
-                                "key_code": "right_control"
-                            }
+                            "from": { "key_code": "caps_lock" },
+                            "to": [{ "key_code": "right_control" }]
                         }
                     ]
                 },
                 {
-                    "disable_built_in_keyboard_if_exists": false,
-                    "fn_function_keys": [],
                     "identifiers": {
                         "is_keyboard": true,
-                        "is_pointing_device": false,
                         "product_id": 635,
                         "vendor_id": 1452
                     },
-                    "ignore": false,
-                    "manipulate_caps_lock_led": true,
                     "simple_modifications": [
                         {
-                            "from": {
-                                "key_code": "caps_lock"
-                            },
-                            "to": {
-                                "key_code": "right_control"
-                            }
+                            "from": { "key_code": "caps_lock" },
+                            "to": [{ "key_code": "right_control" }]
                         }
                     ]
                 },
                 {
-                    "disable_built_in_keyboard_if_exists": false,
-                    "fn_function_keys": [],
                     "identifiers": {
                         "is_keyboard": true,
-                        "is_pointing_device": false,
                         "product_id": 33,
                         "vendor_id": 1278
                     },
-                    "ignore": false,
-                    "manipulate_caps_lock_led": false,
-                    "simple_modifications": []
+                    "manipulate_caps_lock_led": false
                 }
             ],
             "fn_function_keys": [
                 {
-                    "from": {
-                        "key_code": "f1"
-                    },
-                    "to": {
-                        "key_code": "display_brightness_decrement"
-                    }
+                    "from": { "key_code": "f1" },
+                    "to": [{ "key_code": "display_brightness_decrement" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f2"
-                    },
-                    "to": {
-                        "key_code": "display_brightness_increment"
-                    }
+                    "from": { "key_code": "f2" },
+                    "to": [{ "key_code": "display_brightness_increment" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f3"
-                    },
-                    "to": {
-                        "key_code": "mission_control"
-                    }
+                    "from": { "key_code": "f3" },
+                    "to": [{ "key_code": "mission_control" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f4"
-                    },
-                    "to": {
-                        "key_code": "launchpad"
-                    }
+                    "from": { "key_code": "f4" },
+                    "to": [{ "key_code": "launchpad" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f5"
-                    },
-                    "to": {
-                        "key_code": "illumination_decrement"
-                    }
+                    "from": { "key_code": "f5" },
+                    "to": [{ "key_code": "illumination_decrement" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f6"
-                    },
-                    "to": {
-                        "key_code": "illumination_increment"
-                    }
+                    "from": { "key_code": "f6" },
+                    "to": [{ "key_code": "illumination_increment" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f7"
-                    },
-                    "to": {
-                        "key_code": "rewind"
-                    }
+                    "from": { "key_code": "f7" },
+                    "to": [{ "key_code": "rewind" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f8"
-                    },
-                    "to": {
-                        "key_code": "play_or_pause"
-                    }
+                    "from": { "key_code": "f8" },
+                    "to": [{ "key_code": "play_or_pause" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f9"
-                    },
-                    "to": {
-                        "key_code": "fastforward"
-                    }
+                    "from": { "key_code": "f9" },
+                    "to": [{ "key_code": "fastforward" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f10"
-                    },
-                    "to": {
-                        "key_code": "mute"
-                    }
+                    "from": { "key_code": "f10" },
+                    "to": [{ "key_code": "mute" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f11"
-                    },
-                    "to": {
-                        "key_code": "volume_decrement"
-                    }
+                    "from": { "key_code": "f11" },
+                    "to": [{ "key_code": "volume_decrement" }]
                 },
                 {
-                    "from": {
-                        "key_code": "f12"
-                    },
-                    "to": {
-                        "key_code": "volume_increment"
-                    }
+                    "from": { "key_code": "f12" },
+                    "to": [{ "key_code": "volume_increment" }]
                 }
             ],
             "name": "Fun",
-            "parameters": {
-                "delay_milliseconds_before_open_device": 1000
-            },
             "selected": true,
-            "simple_modifications": [],
             "virtual_hid_keyboard": {
                 "caps_lock_delay_milliseconds": 0,
                 "country_code": 0,
                 "keyboard_type": "ansi",
-                "mouse_key_xy_scale": 100
+                "keyboard_type_v2": "ansi"
             }
         }
     ]

--- a/karabiner/karabiner.json
+++ b/karabiner/karabiner.json
@@ -10,11 +10,19 @@
                                 "from": {
                                     "key_code": "h",
                                     "modifiers": {
-                                        "mandatory": ["right_control"],
-                                        "optional": ["caps_lock"]
+                                        "mandatory": [
+                                            "right_control"
+                                        ],
+                                        "optional": [
+                                            "caps_lock"
+                                        ]
                                     }
                                 },
-                                "to": [{ "key_code": "left_arrow" }],
+                                "to": [
+                                    {
+                                        "key_code": "left_arrow"
+                                    }
+                                ],
                                 "type": "basic"
                             }
                         ]
@@ -26,11 +34,19 @@
                                 "from": {
                                     "key_code": "l",
                                     "modifiers": {
-                                        "mandatory": ["right_control"],
-                                        "optional": ["caps_lock"]
+                                        "mandatory": [
+                                            "right_control"
+                                        ],
+                                        "optional": [
+                                            "caps_lock"
+                                        ]
                                     }
                                 },
-                                "to": [{ "key_code": "right_arrow" }],
+                                "to": [
+                                    {
+                                        "key_code": "right_arrow"
+                                    }
+                                ],
                                 "type": "basic"
                             }
                         ]
@@ -42,11 +58,19 @@
                                 "from": {
                                     "key_code": "k",
                                     "modifiers": {
-                                        "mandatory": ["right_control"],
-                                        "optional": ["caps_lock"]
+                                        "mandatory": [
+                                            "right_control"
+                                        ],
+                                        "optional": [
+                                            "caps_lock"
+                                        ]
                                     }
                                 },
-                                "to": [{ "key_code": "up_arrow" }],
+                                "to": [
+                                    {
+                                        "key_code": "up_arrow"
+                                    }
+                                ],
                                 "type": "basic"
                             }
                         ]
@@ -58,11 +82,19 @@
                                 "from": {
                                     "key_code": "j",
                                     "modifiers": {
-                                        "mandatory": ["right_control"],
-                                        "optional": ["caps_lock"]
+                                        "mandatory": [
+                                            "right_control"
+                                        ],
+                                        "optional": [
+                                            "caps_lock"
+                                        ]
                                     }
                                 },
-                                "to": [{ "key_code": "down_arrow" }],
+                                "to": [
+                                    {
+                                        "key_code": "down_arrow"
+                                    }
+                                ],
                                 "type": "basic"
                             }
                         ]
@@ -81,11 +113,19 @@
                                 ],
                                 "from": {
                                     "key_code": "return_or_enter",
-                                    "modifiers": { "mandatory": ["shift"] }
+                                    "modifiers": {
+                                        "mandatory": [
+                                            "shift"
+                                        ]
+                                    }
                                 },
                                 "to": [
-                                    { "key_code": "escape" },
-                                    { "key_code": "return_or_enter" }
+                                    {
+                                        "key_code": "escape"
+                                    },
+                                    {
+                                        "key_code": "return_or_enter"
+                                    }
                                 ],
                                 "type": "basic"
                             }
@@ -103,12 +143,24 @@
                     "manipulate_caps_lock_led": false,
                     "simple_modifications": [
                         {
-                            "from": { "key_code": "left_command" },
-                            "to": [{ "key_code": "left_option" }]
+                            "from": {
+                                "key_code": "left_command"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "left_option"
+                                }
+                            ]
                         },
                         {
-                            "from": { "key_code": "right_option" },
-                            "to": [{ "key_code": "right_command" }]
+                            "from": {
+                                "key_code": "right_option"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "right_command"
+                                }
+                            ]
                         }
                     ]
                 },
@@ -120,67 +172,151 @@
                     },
                     "simple_modifications": [
                         {
-                            "from": { "key_code": "right_option" },
-                            "to": [{ "key_code": "left_command" }]
+                            "from": {
+                                "key_code": "right_option"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "left_command"
+                                }
+                            ]
                         }
                     ]
                 }
             ],
             "fn_function_keys": [
                 {
-                    "from": { "key_code": "f1" },
-                    "to": [{ "key_code": "display_brightness_decrement" }]
+                    "from": {
+                        "key_code": "f1"
+                    },
+                    "to": [
+                        {
+                            "key_code": "display_brightness_decrement"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f2" },
-                    "to": [{ "key_code": "display_brightness_increment" }]
+                    "from": {
+                        "key_code": "f2"
+                    },
+                    "to": [
+                        {
+                            "key_code": "display_brightness_increment"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f3" },
-                    "to": [{ "key_code": "mission_control" }]
+                    "from": {
+                        "key_code": "f3"
+                    },
+                    "to": [
+                        {
+                            "key_code": "mission_control"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f4" },
-                    "to": [{ "key_code": "launchpad" }]
+                    "from": {
+                        "key_code": "f4"
+                    },
+                    "to": [
+                        {
+                            "key_code": "launchpad"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f5" },
-                    "to": [{ "key_code": "illumination_decrement" }]
+                    "from": {
+                        "key_code": "f5"
+                    },
+                    "to": [
+                        {
+                            "key_code": "illumination_decrement"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f6" },
-                    "to": [{ "key_code": "illumination_increment" }]
+                    "from": {
+                        "key_code": "f6"
+                    },
+                    "to": [
+                        {
+                            "key_code": "illumination_increment"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f7" },
-                    "to": [{ "key_code": "rewind" }]
+                    "from": {
+                        "key_code": "f7"
+                    },
+                    "to": [
+                        {
+                            "key_code": "rewind"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f8" },
-                    "to": [{ "key_code": "play_or_pause" }]
+                    "from": {
+                        "key_code": "f8"
+                    },
+                    "to": [
+                        {
+                            "key_code": "play_or_pause"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f9" },
-                    "to": [{ "key_code": "fastforward" }]
+                    "from": {
+                        "key_code": "f9"
+                    },
+                    "to": [
+                        {
+                            "key_code": "fastforward"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f10" },
-                    "to": [{ "key_code": "mute" }]
+                    "from": {
+                        "key_code": "f10"
+                    },
+                    "to": [
+                        {
+                            "key_code": "mute"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f11" },
-                    "to": [{ "key_code": "volume_decrement" }]
+                    "from": {
+                        "key_code": "f11"
+                    },
+                    "to": [
+                        {
+                            "key_code": "volume_decrement"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f12" },
-                    "to": [{ "key_code": "volume_increment" }]
+                    "from": {
+                        "key_code": "f12"
+                    },
+                    "to": [
+                        {
+                            "key_code": "volume_increment"
+                        }
+                    ]
                 }
             ],
             "name": "Default profile",
             "simple_modifications": [
                 {
-                    "from": { "key_code": "caps_lock" },
-                    "to": [{ "key_code": "right_control" }]
+                    "from": {
+                        "key_code": "caps_lock"
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_control"
+                        }
+                    ]
                 }
             ],
             "virtual_hid_keyboard": {
@@ -199,11 +335,19 @@
                                 "from": {
                                     "key_code": "h",
                                     "modifiers": {
-                                        "mandatory": ["right_control"],
-                                        "optional": ["caps_lock"]
+                                        "mandatory": [
+                                            "right_control"
+                                        ],
+                                        "optional": [
+                                            "caps_lock"
+                                        ]
                                     }
                                 },
-                                "to": [{ "key_code": "left_arrow" }],
+                                "to": [
+                                    {
+                                        "key_code": "left_arrow"
+                                    }
+                                ],
                                 "type": "basic"
                             }
                         ]
@@ -215,11 +359,19 @@
                                 "from": {
                                     "key_code": "l",
                                     "modifiers": {
-                                        "mandatory": ["right_control"],
-                                        "optional": ["caps_lock"]
+                                        "mandatory": [
+                                            "right_control"
+                                        ],
+                                        "optional": [
+                                            "caps_lock"
+                                        ]
                                     }
                                 },
-                                "to": [{ "key_code": "right_arrow" }],
+                                "to": [
+                                    {
+                                        "key_code": "right_arrow"
+                                    }
+                                ],
                                 "type": "basic"
                             }
                         ]
@@ -231,11 +383,19 @@
                                 "from": {
                                     "key_code": "k",
                                     "modifiers": {
-                                        "mandatory": ["right_control"],
-                                        "optional": ["caps_lock"]
+                                        "mandatory": [
+                                            "right_control"
+                                        ],
+                                        "optional": [
+                                            "caps_lock"
+                                        ]
                                     }
                                 },
-                                "to": [{ "key_code": "up_arrow" }],
+                                "to": [
+                                    {
+                                        "key_code": "up_arrow"
+                                    }
+                                ],
                                 "type": "basic"
                             }
                         ]
@@ -247,11 +407,19 @@
                                 "from": {
                                     "key_code": "j",
                                     "modifiers": {
-                                        "mandatory": ["right_control"],
-                                        "optional": ["caps_lock"]
+                                        "mandatory": [
+                                            "right_control"
+                                        ],
+                                        "optional": [
+                                            "caps_lock"
+                                        ]
                                     }
                                 },
-                                "to": [{ "key_code": "down_arrow" }],
+                                "to": [
+                                    {
+                                        "key_code": "down_arrow"
+                                    }
+                                ],
                                 "type": "basic"
                             }
                         ]
@@ -263,44 +431,76 @@
                                 "from": {
                                     "key_code": "h",
                                     "modifiers": {
-                                        "mandatory": ["left_control"],
-                                        "optional": ["any"]
+                                        "mandatory": [
+                                            "left_control"
+                                        ],
+                                        "optional": [
+                                            "any"
+                                        ]
                                     }
                                 },
-                                "to": [{ "key_code": "left_arrow" }],
+                                "to": [
+                                    {
+                                        "key_code": "left_arrow"
+                                    }
+                                ],
                                 "type": "basic"
                             },
                             {
                                 "from": {
                                     "key_code": "j",
                                     "modifiers": {
-                                        "mandatory": ["left_control"],
-                                        "optional": ["any"]
+                                        "mandatory": [
+                                            "left_control"
+                                        ],
+                                        "optional": [
+                                            "any"
+                                        ]
                                     }
                                 },
-                                "to": [{ "key_code": "down_arrow" }],
+                                "to": [
+                                    {
+                                        "key_code": "down_arrow"
+                                    }
+                                ],
                                 "type": "basic"
                             },
                             {
                                 "from": {
                                     "key_code": "k",
                                     "modifiers": {
-                                        "mandatory": ["left_control"],
-                                        "optional": ["any"]
+                                        "mandatory": [
+                                            "left_control"
+                                        ],
+                                        "optional": [
+                                            "any"
+                                        ]
                                     }
                                 },
-                                "to": [{ "key_code": "up_arrow" }],
+                                "to": [
+                                    {
+                                        "key_code": "up_arrow"
+                                    }
+                                ],
                                 "type": "basic"
                             },
                             {
                                 "from": {
                                     "key_code": "l",
                                     "modifiers": {
-                                        "mandatory": ["left_control"],
-                                        "optional": ["any"]
+                                        "mandatory": [
+                                            "left_control"
+                                        ],
+                                        "optional": [
+                                            "any"
+                                        ]
                                     }
                                 },
-                                "to": [{ "key_code": "right_arrow" }],
+                                "to": [
+                                    {
+                                        "key_code": "right_arrow"
+                                    }
+                                ],
                                 "type": "basic"
                             }
                         ]
@@ -319,11 +519,19 @@
                                 ],
                                 "from": {
                                     "key_code": "return_or_enter",
-                                    "modifiers": { "mandatory": ["shift"] }
+                                    "modifiers": {
+                                        "mandatory": [
+                                            "shift"
+                                        ]
+                                    }
                                 },
                                 "to": [
-                                    { "key_code": "escape" },
-                                    { "key_code": "return_or_enter" }
+                                    {
+                                        "key_code": "escape"
+                                    },
+                                    {
+                                        "key_code": "return_or_enter"
+                                    }
                                 ],
                                 "type": "basic"
                             }
@@ -341,24 +549,54 @@
                     "manipulate_caps_lock_led": false,
                     "simple_modifications": [
                         {
-                            "from": { "key_code": "caps_lock" },
-                            "to": [{ "key_code": "right_control" }]
+                            "from": {
+                                "key_code": "caps_lock"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "right_control"
+                                }
+                            ]
                         },
                         {
-                            "from": { "key_code": "left_command" },
-                            "to": [{ "key_code": "left_option" }]
+                            "from": {
+                                "key_code": "left_command"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "left_option"
+                                }
+                            ]
                         },
                         {
-                            "from": { "key_code": "left_option" },
-                            "to": [{ "key_code": "left_command" }]
+                            "from": {
+                                "key_code": "left_option"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "left_command"
+                                }
+                            ]
                         },
                         {
-                            "from": { "key_code": "right_command" },
-                            "to": [{ "key_code": "right_option" }]
+                            "from": {
+                                "key_code": "right_command"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "right_option"
+                                }
+                            ]
                         },
                         {
-                            "from": { "key_code": "right_option" },
-                            "to": [{ "key_code": "right_command" }]
+                            "from": {
+                                "key_code": "right_option"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "right_command"
+                                }
+                            ]
                         }
                     ]
                 },
@@ -370,8 +608,14 @@
                     },
                     "simple_modifications": [
                         {
-                            "from": { "key_code": "right_option" },
-                            "to": [{ "key_code": "left_command" }]
+                            "from": {
+                                "key_code": "right_option"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "left_command"
+                                }
+                            ]
                         }
                     ]
                 },
@@ -384,32 +628,74 @@
                     "manipulate_caps_lock_led": false,
                     "simple_modifications": [
                         {
-                            "from": { "key_code": "caps_lock" },
-                            "to": [{ "key_code": "right_control" }]
+                            "from": {
+                                "key_code": "caps_lock"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "right_control"
+                                }
+                            ]
                         },
                         {
-                            "from": { "key_code": "escape" },
-                            "to": [{ "key_code": "grave_accent_and_tilde" }]
+                            "from": {
+                                "key_code": "escape"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "grave_accent_and_tilde"
+                                }
+                            ]
                         },
                         {
-                            "from": { "key_code": "left_command" },
-                            "to": [{ "key_code": "left_option" }]
+                            "from": {
+                                "key_code": "left_command"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "left_option"
+                                }
+                            ]
                         },
                         {
-                            "from": { "key_code": "left_control" },
-                            "to": [{ "key_code": "right_control" }]
+                            "from": {
+                                "key_code": "left_control"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "right_control"
+                                }
+                            ]
                         },
                         {
-                            "from": { "key_code": "left_option" },
-                            "to": [{ "key_code": "left_command" }]
+                            "from": {
+                                "key_code": "left_option"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "left_command"
+                                }
+                            ]
                         },
                         {
-                            "from": { "key_code": "right_command" },
-                            "to": [{ "key_code": "right_option" }]
+                            "from": {
+                                "key_code": "right_command"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "right_option"
+                                }
+                            ]
                         },
                         {
-                            "from": { "key_code": "right_option" },
-                            "to": [{ "key_code": "right_command" }]
+                            "from": {
+                                "key_code": "right_option"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "right_command"
+                                }
+                            ]
                         }
                     ]
                 },
@@ -421,8 +707,14 @@
                     },
                     "simple_modifications": [
                         {
-                            "from": { "key_code": "caps_lock" },
-                            "to": [{ "key_code": "right_control" }]
+                            "from": {
+                                "key_code": "caps_lock"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "right_control"
+                                }
+                            ]
                         }
                     ]
                 },
@@ -434,8 +726,14 @@
                     },
                     "simple_modifications": [
                         {
-                            "from": { "key_code": "caps_lock" },
-                            "to": [{ "key_code": "right_control" }]
+                            "from": {
+                                "key_code": "caps_lock"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "right_control"
+                                }
+                            ]
                         }
                     ]
                 },
@@ -450,52 +748,124 @@
             ],
             "fn_function_keys": [
                 {
-                    "from": { "key_code": "f1" },
-                    "to": [{ "key_code": "display_brightness_decrement" }]
+                    "from": {
+                        "key_code": "f1"
+                    },
+                    "to": [
+                        {
+                            "key_code": "display_brightness_decrement"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f2" },
-                    "to": [{ "key_code": "display_brightness_increment" }]
+                    "from": {
+                        "key_code": "f2"
+                    },
+                    "to": [
+                        {
+                            "key_code": "display_brightness_increment"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f3" },
-                    "to": [{ "key_code": "mission_control" }]
+                    "from": {
+                        "key_code": "f3"
+                    },
+                    "to": [
+                        {
+                            "key_code": "mission_control"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f4" },
-                    "to": [{ "key_code": "launchpad" }]
+                    "from": {
+                        "key_code": "f4"
+                    },
+                    "to": [
+                        {
+                            "key_code": "launchpad"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f5" },
-                    "to": [{ "key_code": "illumination_decrement" }]
+                    "from": {
+                        "key_code": "f5"
+                    },
+                    "to": [
+                        {
+                            "key_code": "illumination_decrement"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f6" },
-                    "to": [{ "key_code": "illumination_increment" }]
+                    "from": {
+                        "key_code": "f6"
+                    },
+                    "to": [
+                        {
+                            "key_code": "illumination_increment"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f7" },
-                    "to": [{ "key_code": "rewind" }]
+                    "from": {
+                        "key_code": "f7"
+                    },
+                    "to": [
+                        {
+                            "key_code": "rewind"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f8" },
-                    "to": [{ "key_code": "play_or_pause" }]
+                    "from": {
+                        "key_code": "f8"
+                    },
+                    "to": [
+                        {
+                            "key_code": "play_or_pause"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f9" },
-                    "to": [{ "key_code": "fastforward" }]
+                    "from": {
+                        "key_code": "f9"
+                    },
+                    "to": [
+                        {
+                            "key_code": "fastforward"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f10" },
-                    "to": [{ "key_code": "mute" }]
+                    "from": {
+                        "key_code": "f10"
+                    },
+                    "to": [
+                        {
+                            "key_code": "mute"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f11" },
-                    "to": [{ "key_code": "volume_decrement" }]
+                    "from": {
+                        "key_code": "f11"
+                    },
+                    "to": [
+                        {
+                            "key_code": "volume_decrement"
+                        }
+                    ]
                 },
                 {
-                    "from": { "key_code": "f12" },
-                    "to": [{ "key_code": "volume_increment" }]
+                    "from": {
+                        "key_code": "f12"
+                    },
+                    "to": [
+                        {
+                            "key_code": "volume_increment"
+                        }
+                    ]
                 }
             ],
             "name": "Fun",
@@ -505,7 +875,19 @@
                 "country_code": 0,
                 "keyboard_type": "ansi",
                 "keyboard_type_v2": "ansi"
-            }
+            },
+            "simple_modifications": [
+                {
+                    "from": {
+                        "key_code": "caps_lock"
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_control"
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/modules/static/75-fzf.sh
+++ b/modules/static/75-fzf.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
+# Module: fzf
+# Description: fzf keybindings and completion (any machine, any install method)
+# Dependencies: fzf (optional)
 
-[ -f ~/.fzf.bash ] && source ~/.fzf.bash
+# Prefer fzf's built-in loader (fzf >= 0.48, works wherever fzf is on
+# PATH); fall back to the legacy install-script file. Cached because the
+# loader output only changes when fzf is upgraded.
+if command -v fzf &>/dev/null; then
+  if [[ "${DOTFILES_CACHE_EVALS:-true}" == "true" ]] && command -v cache_eval &>/dev/null; then
+    cache_eval "fzf_bash" 86400 "fzf --bash"
+  else
+    eval "$(fzf --bash 2>/dev/null)"
+  fi
+elif [[ -f ~/.fzf.bash ]]; then
+  source ~/.fzf.bash
+fi
 
 alias vimf='vim "$(fzf)"'

--- a/modules/static/75-fzf.sh
+++ b/modules/static/75-fzf.sh
@@ -3,6 +3,13 @@
 # Description: fzf keybindings and completion (any machine, any install method)
 # Dependencies: fzf (optional)
 
+# fzf's keybinding/completion script isn't clean under the strict
+# set -E + ERR trap that bash_profile keeps active while static modules
+# load, so suspend strict handling around it and restore afterwards.
+_fzf_prev_err_trap="$(trap -p ERR)"
+trap - ERR
+set +E
+
 # Prefer fzf's built-in loader (fzf >= 0.48, works wherever fzf is on
 # PATH); fall back to the legacy install-script file. Cached because the
 # loader output only changes when fzf is upgraded.
@@ -15,5 +22,11 @@ if command -v fzf &>/dev/null; then
 elif [[ -f ~/.fzf.bash ]]; then
   source ~/.fzf.bash
 fi
+
+set -E
+if [[ -n "$_fzf_prev_err_trap" ]]; then
+  eval "$_fzf_prev_err_trap"
+fi
+unset _fzf_prev_err_trap
 
 alias vimf='vim "$(fzf)"'

--- a/modules/static/95-colors.sh
+++ b/modules/static/95-colors.sh
@@ -16,46 +16,72 @@ BASE16_SHELL="$HOME/.config/base16-shell/"
 # Theme Switching
 # ============================================================================
 
-# Unified theme switching for iTerm2, macOS, base16, vim, and tmux
-# Requires: dark-mode (brew install dark-mode)
+# Unified theme switching for the terminal, macOS, base16, vim, and tmux.
+# Terminal-specific integrations are opt-in by detection ($TERM_PROGRAM);
+# everything else works in any terminal.
 theme-switch() {
   local theme="$1"
+  if [[ "$theme" != "dark" && "$theme" != "light" ]]; then
+    echo "usage: theme-switch <dark|light>" >&2
+    return 1
+  fi
 
-  # Set iTerm2 profile
-  echo -e "\033]50;SetProfile=$theme\a"
+  # Canonical theme variable; tmux.conf and vim honor it in any terminal
+  export DOTFILES_THEME="$theme"
 
-  if [[ "$theme" == "dark" ]]; then
-    # macOS dark mode
-    dark-mode on 2>/dev/null
+  # --- terminal emulator colors: per-terminal adapters ---
+  case "${TERM_PROGRAM:-}" in
+    iTerm.app)
+      # Switch to the iTerm2 profile named after the theme
+      echo -e "\033]50;SetProfile=$theme\a"
+      ;;
+    Apple_Terminal)
+      # Terminal.app ignores OSC palette escapes; switch its profile via
+      # AppleScript instead. Profile names are overridable via
+      # DOTFILES_TERMINAL_PROFILE_DARK / DOTFILES_TERMINAL_PROFILE_LIGHT.
+      local profile
+      if [[ "$theme" == "dark" ]]; then
+        profile="${DOTFILES_TERMINAL_PROFILE_DARK:-Clear Dark}"
+      else
+        profile="${DOTFILES_TERMINAL_PROFILE_LIGHT:-Clear Light}"
+      fi
+      if ! osascript >/dev/null 2>&1 <<APPLESCRIPT
+tell application "Terminal"
+  set default settings to settings set "$profile"
+  repeat with w in windows
+    try
+      set current settings of tabs of w to settings set "$profile"
+    end try
+  end repeat
+end tell
+APPLESCRIPT
+      then
+        echo "theme-switch: could not switch Terminal.app to profile '$profile'" >&2
+      fi
+      ;;
+  esac
 
-    # Shell colors (base16 or iTerm2 fallback)
-    base16_solarized-dark 2>/dev/null || it2setcolor preset 'Solarized Dark'
-
-    # Vim/Tmux line
-    nvim -c ":set background=dark" +Tmuxline +qall 2>/dev/null
-
-    # Tmux colors
-    if tmux info &>/dev/null; then
-      echo "Setting tmux environment to dark"
-      tmux set-environment ITERM_PROFILE dark
-      tmux source-file ~/.tmux/plugins/tmux-colors-solarized/tmuxcolors-dark.conf 2>/dev/null
+  # --- macOS system appearance (osascript first, dark-mode CLI fallback) ---
+  if [[ "$OSTYPE" == darwin* ]]; then
+    local dark_mode="false"
+    [[ "$theme" == "dark" ]] && dark_mode="true"
+    if ! osascript -e "tell application \"System Events\" to tell appearance preferences to set dark mode to $dark_mode" >/dev/null 2>&1; then
+      if [[ "$theme" == "dark" ]]; then dark-mode on 2>/dev/null; else dark-mode off 2>/dev/null; fi
     fi
-  else
-    # macOS light mode
-    dark-mode off 2>/dev/null
+  fi
 
-    # Shell colors (base16 or iTerm2 fallback)
-    base16_solarized-light 2>/dev/null || it2setcolor preset 'Solarized Light'
+  # --- shell colors (base16; works in any OSC-4-capable terminal) ---
+  "base16_solarized-${theme}" 2>/dev/null || true
 
-    # Vim/Tmux line
-    nvim -c ":set background=light" +Tmuxline +qall 2>/dev/null
+  # --- vim background + airline/tmuxline ---
+  nvim -c ":set background=${theme}" +Tmuxline +qall 2>/dev/null
 
-    # Tmux colors
-    if tmux info &>/dev/null; then
-      echo "Setting tmux environment to light"
-      tmux set-environment ITERM_PROFILE light
-      tmux source-file ~/.tmux/plugins/tmux-colors-solarized/tmuxcolors-light.conf 2>/dev/null
-    fi
+  # --- tmux colors ---
+  if tmux info &>/dev/null; then
+    echo "Setting tmux environment to ${theme}"
+    tmux set-environment DOTFILES_THEME "$theme"
+    tmux set-environment ITERM_PROFILE "$theme" # legacy consumers
+    tmux source-file "${HOME}/.tmux/plugins/tmux-colors-solarized/tmuxcolors-${theme}.conf" 2>/dev/null
   fi
 }
 

--- a/modules/static/darwin/30-keyrepeat.sh
+++ b/modules/static/darwin/30-keyrepeat.sh
@@ -10,5 +10,15 @@
 fix-key-repeat() {
   source "${DOTFILES_DIR}/modules/dynamic/darwin/osx_defaults.sh"
   echo "Key repeat restored (KeyRepeat=1, InitialKeyRepeat=11)."
-  echo "Log out and back in for the change to take effect."
+  # Karabiner's virtual keyboard reads these values only when it is
+  # created, so kick its user service to recreate it — this makes the
+  # change take effect immediately, no logout needed.
+  local karabiner_service
+  karabiner_service="gui/$(id -u)/org.pqrs.service.agent.karabiner_console_user_server"
+  if launchctl print "$karabiner_service" &>/dev/null; then
+    launchctl kickstart -k "$karabiner_service"
+    echo "Karabiner virtual keyboard recreated; settings are live now."
+  else
+    echo "Log out and back in for the change to take effect."
+  fi
 }

--- a/modules/static/darwin/30-keyrepeat.sh
+++ b/modules/static/darwin/30-keyrepeat.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Module: keyrepeat
+# Description: helper to restore fast key repeat settings
+# Dependencies: modules/dynamic/darwin/osx_defaults.sh
+
+# The Keyboard pane in System Settings rewrites KeyRepeat/InitialKeyRepeat
+# to slider-quantized values whenever its sliders move, clobbering the
+# faster-than-UI values from osx_defaults.sh (the dynamic module is
+# hash-gated, so it won't notice). Run this to reapply them.
+fix-key-repeat() {
+  source "${DOTFILES_DIR}/modules/dynamic/darwin/osx_defaults.sh"
+  echo "Key repeat restored (KeyRepeat=1, InitialKeyRepeat=11)."
+  echo "Log out and back in for the change to take effect."
+}

--- a/modules/static/darwin/85-iterm2.sh
+++ b/modules/static/darwin/85-iterm2.sh
@@ -4,4 +4,6 @@
 # Dependencies: none
 
 # Load iTerm2 shell integration if available
-[[ -f "${HOME}/.iterm2_shell_integration.bash" ]] && source "${HOME}/.iterm2_shell_integration.bash"
+if [[ -f "${HOME}/.iterm2_shell_integration.bash" ]]; then
+  source "${HOME}/.iterm2_shell_integration.bash"
+fi

--- a/tests/test_dotfiles.py
+++ b/tests/test_dotfiles.py
@@ -6,6 +6,8 @@ Tests for dot.py - Verifies behavior of zero-dependency refactored version.
 import os
 import sys
 
+import pytest
+
 # Add parent directory to path so we can import dot
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -181,6 +183,43 @@ class TestIssue3Fixed:
         assert "def cmd_link" in content or "def main" in content
         # The bug has been fixed in the refactored version
         pass
+
+
+class TestLoadConfig:
+    """Test config loading: JSON always, YAML when PyYAML is available"""
+
+    def test_load_config_json(self, temp_dir):
+        """Test loading a JSON config"""
+        config_file = temp_dir / "dotfiles.json"
+        config_file.write_text('{"home": "~/", "links": {"~/.testrc": "test/testrc"}}')
+
+        config = dot.load_config(str(config_file))
+
+        assert config["home"] == "~/"
+        assert config["links"] == {"~/.testrc": "test/testrc"}
+
+    @pytest.mark.skipif(dot.yaml is None, reason="PyYAML not installed")
+    def test_load_config_yaml(self, sample_yaml_config):
+        """Test loading a YAML config when PyYAML is available"""
+        config = dot.load_config(sample_yaml_config)
+
+        assert config["home"] == "~/"
+        assert config["links"]["~/.testrc"] == "test/testrc"
+
+    def test_load_config_yaml_without_pyyaml(self, sample_yaml_config, monkeypatch):
+        """Test that a YAML config without PyYAML aborts with an error"""
+        monkeypatch.setattr(dot, "yaml", None)
+
+        with pytest.raises(SystemExit):
+            dot.load_config(sample_yaml_config)
+
+    def test_load_config_invalid_json(self, temp_dir):
+        """Test that invalid JSON aborts with an error"""
+        config_file = temp_dir / "dotfiles.json"
+        config_file.write_text("not json {")
+
+        with pytest.raises(SystemExit):
+            dot.load_config(str(config_file))
 
 
 # Note: Full integration tests for link/unlink commands with argparse CLI

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -63,9 +63,11 @@ set -g @resurrect-hook-post-save-all 'bash ~/.config/tmux-claude-resume/resurrec
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '$HOME/.tmux/plugins/tpm/tpm'
 
-# Disable this for iterm2
-setw -g aggressive-resize off
+# aggressive-resize breaks iTerm2's tmux integration; enable it elsewhere
+if '[ "${TERM_PROGRAM:-}" = "iTerm.app" ]' 'setw -g aggressive-resize off' 'setw -g aggressive-resize on'
 
-if '[ "$ITERM_PROFILE" = "dark" ]' 'source -q $HOME/.tmux/plugins/tmux-colors-solarized/tmuxcolors-dark.conf' ''
-if '[ "$ITERM_PROFILE" = "light" ]' 'source -q $HOME/.tmux/plugins/tmux-colors-solarized/tmuxcolors-light.conf' ''
-set -g @colors-solarized "$ITERM_PROFILE"
+# Solarized colors follow the theme: DOTFILES_THEME wins, then the legacy
+# ITERM_PROFILE, defaulting to dark so any terminal gets sane colors.
+if '[ "${DOTFILES_THEME:-${ITERM_PROFILE:-dark}}" = "light" ]' \
+  'source -q $HOME/.tmux/plugins/tmux-colors-solarized/tmuxcolors-light.conf ; set -g @colors-solarized light' \
+  'source -q $HOME/.tmux/plugins/tmux-colors-solarized/tmuxcolors-dark.conf ; set -g @colors-solarized dark'

--- a/vim/samstav-vimrc/plugin/samstav.vim
+++ b/vim/samstav-vimrc/plugin/samstav.vim
@@ -234,11 +234,14 @@ augroup END
 
 """""""""" match iterm / colors
 
+" Default to dark; an explicit light profile (e.g. iTerm2) overrides.
+" $ITERM_PROFILE is unset in other terminals (Terminal.app etc.), and
+" defaulting to light there was wrong far more often than not.
 let iterm_profile = $ITERM_PROFILE
-if iterm_profile == "dark"
-    set background=dark
-else
+if iterm_profile == "light"
     set background=light
+else
+    set background=dark
 endif
 
 if filereadable(expand("~/.vimrc_background"))

--- a/vim/samstav-vimrc/plugin/samstav.vim
+++ b/vim/samstav-vimrc/plugin/samstav.vim
@@ -234,11 +234,11 @@ augroup END
 
 """""""""" match iterm / colors
 
-" Default to dark; an explicit light profile (e.g. iTerm2) overrides.
-" $ITERM_PROFILE is unset in other terminals (Terminal.app etc.), and
+" Default to dark; an explicit light theme overrides. DOTFILES_THEME is
+" the canonical theme variable (set by theme-switch); ITERM_PROFILE is
+" honored as a legacy fallback. Both are unset in most terminals, and
 " defaulting to light there was wrong far more often than not.
-let iterm_profile = $ITERM_PROFILE
-if iterm_profile == "light"
+if $DOTFILES_THEME == "light" || ($DOTFILES_THEME == "" && $ITERM_PROFILE == "light")
     set background=light
 else
     set background=dark

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -3,8 +3,10 @@
 "
 call plug#begin()
 
-" fzf
-Plug '/usr/local/opt/fzf'
+" fzf — upstream plugin instead of a hardcoded Homebrew path (which
+" differs across Intel/Apple Silicon/Linux); it uses fzf from PATH or
+" installs its own binary
+Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
 Plug 'junegunn/fzf.vim'
 
 " did you mean?


### PR DESCRIPTION
Fixes and improvements from setting up these dotfiles on a fresh macOS (Tahoe) machine, using the built-in Terminal.app instead of iTerm2.

## What's in here

- **fix(shell):** trailing `[[ ... ]] &&` / `test ... &&` conditionals in `bash_profile` and the iTerm2 module returned nonzero when iTerm2 shell integration (or Pulumi) was absent, tripping the ERR trap on every startup and leaving the shell's initial `$?` at 1. Converted to `if` statements — startup is now clean in any terminal.
- **feat(dot):** `dot.py` only read JSON but the repo manifest is `dotfiles.yaml`, so `./dot.py link` had no config on a fresh clone. Committed a generated `dotfiles.json` (the zero-dependency default path) and taught `load_config()` to optionally parse YAML when PyYAML is installed — `import yaml` is wrapped in try/except so dot.py stays dependency-free; `main()` falls back to `dotfiles.yaml` when the default JSON is absent. Includes tests.
- **feat(install):** `install.sh` now checks the login shell — the dotfiles only load under bash, but fresh macOS defaults to zsh with bash 3.2 — finds the best bash ≥ 4.3 (brew prefix first), and offers to add it to `/etc/shells` and `chsh`. Always asks first; prints manual commands when non-interactive. Also fixes install.sh idempotency: the pyenv check now looks at `~/.pyenv/bin/pyenv`, not just PATH, so re-runs no longer trip pyenv-installer's "already exists" abort.
- **feat(karabiner):** Apple Terminal transmits identical bytes for Return and Shift+Return (see anthropics/claude-code#62322) and its Keyboard settings can't bind Return, so Shift+Enter-for-newline can't work there natively. Added a Karabiner rule (both profiles): shift+return → escape,return, scoped to `com.apple.Terminal` so other terminals keep native handling.
- **chore(karabiner):** config sync after Karabiner-Elements 16 rewrote the file into its compact format on first launch (all rules verified intact).

## Verified

- Full quality gate locally with CI-pinned versions: ruff check + format, mypy, pytest (16 passed), shellcheck on all touched shell files
- `dot.py link` exercised end-to-end in all three modes: JSON config, YAML config with PyYAML, YAML without PyYAML (clean error)
- Shell startup: clean, `$?`=0, ~65ms; `install.sh` re-run idempotent
- Shift+Enter newline confirmed working in Claude Code under Terminal.app via the Karabiner rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)